### PR TITLE
Cherry picks from today's work (see below)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 BOOTSTRAP=1
 ARGO_TARGET_NAMESPACE=manuela-ci
+PATTERN=industrial-edge
+COMPONENT=datacenter
+SECRET_NAME="argocd-env"
 
 .PHONY: default
 default: show
@@ -9,12 +12,14 @@ default: show
 
 install: deploy
 ifeq ($(BOOTSTRAP),1)
-	make -f common/Makefile TARGET_NAMESPACE=$(ARGO_TARGET_NAMESPACE) argosecret
+	make secret
 	make sleep-seed
 endif
 
 secret:
-	make -f common/Makefile TARGET_NAMESPACE=$(ARGO_TARGET_NAMESPACE) argosecret
+	make -f common/Makefile \
+		PATTERN=$(PATTERN) TARGET_NAMESPACE=$(ARGO_TARGET_NAMESPACE) \
+		SECRET_NAME=$(SECRET_NAME) COMPONENT=$(COMPONENT) argosecret
 
 sleep-seed:
 	echo "Waiting for pipeline seed to be created in manuela-ci"

--- a/charts/datacenter/pipelines/extra/build-and-test-run.yaml
+++ b/charts/datacenter/pipelines/extra/build-and-test-run.yaml
@@ -7,11 +7,6 @@ metadata:
     argocd.argoproj.io/instance: pipelines-industrial-edge-datacenter
     tekton.dev/pipeline: build-and-test
 spec:
-  params:
-    - name: DEV_REVISION
-      value: main
-    - name: OPS_REVISION
-      value: main
   pipelineRef:
     name: build-and-test
   serviceAccountName: pipeline

--- a/charts/datacenter/pipelines/templates/pipelines/build-and-test.yaml
+++ b/charts/datacenter/pipelines/templates/pipelines/build-and-test.yaml
@@ -295,7 +295,8 @@ spec:
       workspace: argocd-env-secret
     params:
     - name: application-name
-      value: manuela-test-{{ .Values.global.pattern }}-{{ .Values.site.name }}
+      #value: manuela-test-{{ .Values.global.pattern }}-{{ .Values.site.name }}
+      value: manuela-test
     - name: flags
       value: --insecure
     - name: argocd-version

--- a/charts/datacenter/pipelines/templates/pipelines/build-and-test.yaml
+++ b/charts/datacenter/pipelines/templates/pipelines/build-and-test.yaml
@@ -302,6 +302,9 @@ spec:
       value: "v1.5.2"
     - name: revision
       value: $(params.OPS_REVISION)
+    - name: argocd-server
+      # datacenter-gitops-server.industrial-edge-datacenter.svc
+      value: "{{ .Values.site.name.}}-gitops-server.{{ .Values.global.pattern }}-{{ .Values.site.name }}.svc"
 
   # - name: sensor-broker-test
   #   taskRef:

--- a/charts/datacenter/pipelines/templates/pipelines/build-and-test.yaml
+++ b/charts/datacenter/pipelines/templates/pipelines/build-and-test.yaml
@@ -304,7 +304,7 @@ spec:
       value: $(params.OPS_REVISION)
     - name: argocd-server
       # datacenter-gitops-server.industrial-edge-datacenter.svc
-      value: "{{ .Values.site.name.}}-gitops-server.{{ .Values.global.pattern }}-{{ .Values.site.name }}.svc"
+      value: "{{ .Values.site.name }}-gitops-server.{{ .Values.global.pattern }}-{{ .Values.site.name }}.svc"
 
   # - name: sensor-broker-test
   #   taskRef:

--- a/values-datacenter.yaml
+++ b/values-datacenter.yaml
@@ -45,7 +45,7 @@ site:
     channel: amq-streams-1.7.x
     csv: amqstreams.v1.7.1
 
-  - name: amqbroker
+  - name: amq-broker
     namespace: manuela-tst-all
     channel: 7.8.x
     csv: amq-broker-operator.v7.8.1-opr-3


### PR DESCRIPTION
* Suitable for 2.0-stable *

1) Update common.  This is necessary for makefile fixes for argo namespacing.
2) Update template name for build-and-test argo sync and wait target (for argo namespacing) (and fix a typo while working that out)
3) Hardcode manuela-test as the app for CI
4) Ensure amq-broker has the dash; operators don't come up without it
5) Fix 'make build-and-test' to honor defaults as defaults are templated by helm