### PR TITLE
Fix sleep-seed to track tkn dependency too

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,17 @@ secret:
 		PATTERN=$(PATTERN) TARGET_NAMESPACE=$(ARGO_TARGET_NAMESPACE) \
 		SECRET_NAME=$(SECRET_NAME) COMPONENT=$(COMPONENT) argosecret
 
+.ONESHELL:
+SHELL = bash
 sleep-seed:
-	echo "Waiting for pipeline seed to be created in manuela-ci"
-	while [ 1 ]; do oc get -n manuela-ci pipeline seed 1>/dev/null 2>/dev/null && make seed 1>/dev/null 2>/dev/null && echo "Bootstrap seed now running" && break; sleep 5; done
+	while [ 1 ]; do 
+		echo "Waiting for seed resources to be ready in manuela-ci"
+		oc get -n manuela-ci pipeline seed 1>/dev/null 2>/dev/null && \
+		oc get -n manuela-ci task tkn 1>/dev/null 2>/dev/null && \
+		make seed 1>/dev/null 2>/dev/null && \
+		echo "Bootstrap seed now running" && break; 
+		sleep 5;
+	done
 
 seed:
 	oc create -f charts/datacenter/pipelines/extra/seed-run.yaml


### PR DESCRIPTION
We need to watch for more resources than just the pipeline - the seed pipeline only depends on the tkn task, so this will work.  Generalizing this idea might require a different approach.