### PR TITLE
Factor .ONESHELL logic out of makefile to improve compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,17 +21,10 @@ secret:
 		PATTERN=$(PATTERN) TARGET_NAMESPACE=$(ARGO_TARGET_NAMESPACE) \
 		SECRET_NAME=$(SECRET_NAME) COMPONENT=$(COMPONENT) argosecret
 
-.ONESHELL:
-SHELL = bash
-sleep-seed:
-	while [ 1 ]; do 
-		echo "Waiting for seed resources to be ready in manuela-ci"
-		oc get -n manuela-ci pipeline seed 1>/dev/null 2>/dev/null && \
-		oc get -n manuela-ci task tkn 1>/dev/null 2>/dev/null && \
-		make seed 1>/dev/null 2>/dev/null && \
-		echo "Bootstrap seed now running" && break; 
-		sleep 5;
-	done
+sleep:
+	scripts/sleep-seed.sh
+
+sleep-seed: sleep seed
 
 seed:
 	oc create -f charts/datacenter/pipelines/extra/seed-run.yaml

--- a/scripts/sleep-seed.sh
+++ b/scripts/sleep-seed.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+while [ 1 ]; do
+	echo "Waiting for seed resources to be ready in manuela-ci"
+	oc get -n manuela-ci pipeline seed 1>/dev/null 2>/dev/null && \
+    oc get -n manuela-ci task tkn 1>/dev/null 2>/dev/null && \
+    echo "Bootstrap seed now running" && break;
+	sleep 5;
+done
+
+exit 0
+

--- a/scripts/sleep-seed.sh
+++ b/scripts/sleep-seed.sh
@@ -3,8 +3,8 @@
 while [ 1 ]; do
 	echo "Waiting for seed resources to be ready in manuela-ci"
 	oc get -n manuela-ci pipeline seed 1>/dev/null 2>/dev/null && \
-    oc get -n manuela-ci task tkn 1>/dev/null 2>/dev/null && \
-    echo "Bootstrap seed now running" && break;
+	oc get -n manuela-ci task tkn 1>/dev/null 2>/dev/null && \
+	echo "Bootstrap seed now running" && break;
 	sleep 5;
 done
 


### PR DESCRIPTION
.ONESHELL is only supported in GNU Make 3.82+.  MacOS ships with 3.81.

This separates the targets so that sleed-seed.sh now only waits until the resources are ready, and then turns control back over to the seed target