### PR TITLE
Add pipelines and makefile jobs to enable building and testing just iot-consumer and iot-anomaly-detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,3 +32,9 @@ seed:
 
 build-and-test:
 	oc create -f charts/datacenter/pipelines/extra/build-and-test-run.yaml
+
+build-and-test-iot-anomaly-detection:
+	oc create -f charts/datacenter/pipelines/extra/build-and-test-run-iot-anomaly-detection.yaml
+
+build-and-test-iot-consumer:
+	oc create -f charts/datacenter/pipelines/extra/build-and-test-run-iot-consumer.yaml

--- a/charts/datacenter/pipelines/extra/build-and-test-run-iot-anomaly-detection.yaml
+++ b/charts/datacenter/pipelines/extra/build-and-test-run-iot-anomaly-detection.yaml
@@ -8,7 +8,7 @@ metadata:
     tekton.dev/pipeline: build-and-test-iot-anomaly-detection
 spec:
   pipelineRef:
-    name: build-and-test
+    name: build-and-test-iot-anomaly-detection
   serviceAccountName: pipeline
   timeout: 1h0m0s
   workspaces:

--- a/charts/datacenter/pipelines/extra/build-and-test-run-iot-anomaly-detection.yaml
+++ b/charts/datacenter/pipelines/extra/build-and-test-run-iot-anomaly-detection.yaml
@@ -1,0 +1,32 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: build-and-test-run-iot-anomaly-detection-
+  namespace: manuela-ci
+  labels:
+    argocd.argoproj.io/instance: pipelines-industrial-edge-datacenter
+    tekton.dev/pipeline: build-and-test-iot-anomaly-detection
+spec:
+  pipelineRef:
+    name: build-and-test
+  serviceAccountName: pipeline
+  timeout: 1h0m0s
+  workspaces:
+    - name: gitrepos
+      persistentVolumeClaim:
+        claimName: gitrepos-rwo
+    - configMap:
+        name: environment
+      name: config
+    - name: github-secret
+      secret:
+        secretName: github
+    - name: argocd-env-secret
+      secret:
+        secretName: argocd-env
+    - name: build-artifacts
+      persistentVolumeClaim:
+        claimName: build-artifacts-rwo
+    - name: quay-secret
+      secret:
+        secretName: quay-build-secret

--- a/charts/datacenter/pipelines/extra/build-and-test-run-iot-consumer.yaml
+++ b/charts/datacenter/pipelines/extra/build-and-test-run-iot-consumer.yaml
@@ -8,7 +8,7 @@ metadata:
     tekton.dev/pipeline: build-and-test-iot-consumer
 spec:
   pipelineRef:
-    name: build-and-test
+    name: build-and-test-iot-consumer
   serviceAccountName: pipeline
   timeout: 1h0m0s
   workspaces:

--- a/charts/datacenter/pipelines/extra/build-and-test-run-iot-consumer.yaml
+++ b/charts/datacenter/pipelines/extra/build-and-test-run-iot-consumer.yaml
@@ -1,0 +1,32 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: build-and-test-run-iot-consumer-
+  namespace: manuela-ci
+  labels:
+    argocd.argoproj.io/instance: pipelines-industrial-edge-datacenter
+    tekton.dev/pipeline: build-and-test-iot-consumer
+spec:
+  pipelineRef:
+    name: build-and-test
+  serviceAccountName: pipeline
+  timeout: 1h0m0s
+  workspaces:
+    - name: gitrepos
+      persistentVolumeClaim:
+        claimName: gitrepos-rwo
+    - configMap:
+        name: environment
+      name: config
+    - name: github-secret
+      secret:
+        secretName: github
+    - name: argocd-env-secret
+      secret:
+        secretName: argocd-env
+    - name: build-artifacts
+      persistentVolumeClaim:
+        claimName: build-artifacts-rwo
+    - name: quay-secret
+      secret:
+        secretName: quay-build-secret

--- a/charts/datacenter/pipelines/templates/configmaps/environment.yaml
+++ b/charts/datacenter/pipelines/templates/configmaps/environment.yaml
@@ -33,5 +33,4 @@ data:
   IOT_ANOMALY_YAML_PATH: 'images(name==anomaly-detection).newTag'
   IOT_ANOMALY_TEST_KUSTOMIZATION_PATH: charts/datacenter/manuela-tst/kustomization.yaml
   IOT_ANOMALY_PROD_KUSTOMIZATION_PATH: charts/factory/manuela-stormshift/kustomization.yaml
-  # This seems wrong!!!
   IOT_ANOMALY_PROD_IMAGESTREAM_PATH: charts/factory/manuela-stormshift/templates/anomaly-detection/anomaly-detection-is.yaml

--- a/charts/datacenter/pipelines/templates/pipelines/build-and-test-iot-anomaly-detection.yaml
+++ b/charts/datacenter/pipelines/templates/pipelines/build-and-test-iot-anomaly-detection.yaml
@@ -1,0 +1,231 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: build-and-test-iot-anomaly-detection
+spec:
+  workspaces:
+  - name: gitrepos
+  - name: config
+  - name: github-secret
+  - name: quay-secret
+  - name: build-artifacts
+
+  tasks:
+  - name: git-clone-dev
+    taskRef:
+      name: git-clone-with-tags
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: config
+      workspace: config
+    params:
+    - name: url_configmapkey
+      value: GIT_DEV_REPO_URL
+    - name: revision
+      value: {{ .Values.global.git.dev_revision }}
+    - name: subdirectory
+      value: dev
+    - name: deleteExisting
+      value: "true"
+
+  - name: git-clone-ops
+    taskRef:
+      name: git-clone-with-tags
+    runAfter:
+    - git-clone-dev
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: config
+      workspace: config
+    params:
+    - name: url_configmapkey
+      value: GIT_OPS_REPO_TEST_URL
+    - name: revision
+      value: {{ .Values.global.targetRevision }}
+    - name: subdirectory
+      value: ops
+    - name: deleteExisting
+      value: "true"
+
+  - name: bump-build-version-iot-anomaly
+    taskRef:
+      name: bumpversion
+    runAfter:
+    - git-clone-ops
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    params:
+    - name: component_name
+      value: iot-anomaly
+    - name: version_file_path
+      value: components/iot-anomaly-detection/VERSION
+
+  - name: s2i-build-iot-anomaly
+    taskRef:
+      name: s2i
+    runAfter:
+    - bump-build-version-iot-anomaly
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: build-artifacts
+      workspace: build-artifacts
+    params:
+    - name: TLSVERIFY
+      value: "false"
+    - name: PATH_CONTEXT
+      value: components/iot-anomaly-detection
+    - name: BUILDER_IMAGE
+      value: registry.access.redhat.com/rhscl/python-36-rhel7
+    - name: TAG
+      value: $(tasks.bump-build-version-iot-anomaly.results.image-tag)
+    - name: OUTPUT_IMAGE
+      value: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/anomaly-detection
+
+  - name: copy-image-to-remote-registry-iot-anomaly
+    taskRef:
+      name: skopeo-copy
+    runAfter: 
+    - s2i-build-iot-anomaly
+    workspaces:
+    - name: config
+      workspace: config
+    - name: pushsecret
+      workspace: quay-secret
+    params:
+    - name: TAG
+      value: $(tasks.bump-build-version-iot-anomaly.results.image-tag)
+    - name: SOURCE_IMAGE
+      value: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/anomaly-detection
+    - name: TARGET_IMAGE_CONFIGMAPKEY
+      value: IOT_ANOMALY_IMAGE
+
+  - name: push-dev-tag
+    taskRef:
+      name: github-push
+    runAfter:
+    - copy-image-to-remote-registry-iot-anomaly
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: github-secret
+      workspace: github-secret
+    params:
+    - name: PUSH_FLAGS
+      value: --tags
+
+  - name: modify-ops-test-iot-anomaly
+    taskRef:
+      name: gitops-imagetag
+    runAfter:
+    - push-dev-tag
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: config
+      workspace: config
+    params:
+    - name: CONFIGMAP_PREFIX
+      value: IOT_ANOMALY
+    - name: ENVIRONMENT
+      value: TEST
+    - name: TAG
+      value: $(tasks.bump-build-version-iot-anomaly.results.image-tag)
+    - name: subdirectory
+      value: ops
+
+  - name: commit-ops
+    taskRef:
+      name: git-commit
+    runAfter:
+    - modify-ops-test-iot-anomaly
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: config
+      workspace: config
+    params:
+    - name: subdirectory
+      value: ops
+
+  - name: push-ops
+    taskRef:
+      name: github-push
+    runAfter:
+    - commit-ops
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: github-secret
+      workspace: github-secret
+    params:
+    - name: subdirectory
+      value: ops
+
+  - name: argocd-sync-application
+    taskRef:
+      name: argocd-sync-and-wait
+    runAfter:
+    - push-ops
+    workspaces:
+    - name: argocd-env-secret
+      workspace: argocd-env-secret
+    params:
+    - name: application-name
+      #value: manuela-test-{{ .Values.global.pattern }}-{{ .Values.site.name }}
+      value: manuela-test
+    - name: flags
+      value: --insecure
+    - name: argocd-version
+      value: "v1.5.2"
+    - name: revision
+      value: $(params.OPS_REVISION)
+    - name: argocd-server
+      # datacenter-gitops-server.industrial-edge-datacenter.svc
+      value: "{{ .Values.site.name }}-gitops-server.{{ .Values.global.pattern }}-{{ .Values.site.name }}.svc"
+
+ - name: test-all
+    taskRef:
+      name: tkn
+    runAfter:
+    - argocd-sync-application
+    params:
+    - name: ARGS
+      value:
+      - pipeline
+      - start
+      - test-all
+      - --showlog
+      - --nocolour
+
+  - name: trigger-staging
+    taskRef:
+      name: openshift-instantiate-template
+    runAfter:
+    - test-all
+    params:
+    - name: TEMPLATE
+      value: stage-production-pipelinerun
+    - name: PARAMS
+      value: -p TAG=$(tasks.bump-build-version.results.image-tag) -p CONFIGMAP_PREFIX=IOT_ANOMALY -p SOURCE_IMAGE=image-registry.openshift-image-registry.svc:5000/manuela-tst-all/anomaly-detection -p COMPONENT_NAME=iot-anomaly-detection
+
+  - name: cleanup
+    taskRef:
+      name: cleanup
+    runAfter:
+    - trigger-staging
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: config
+      workspace: config
+    - name: github-secret
+      workspace: github-secret
+    params:
+    - name: subdirectory
+      value: dev
+    - name: COMPONENT_NAME
+      value: iot-anomaly-detection

--- a/charts/datacenter/pipelines/templates/pipelines/build-and-test-iot-anomaly-detection.yaml
+++ b/charts/datacenter/pipelines/templates/pipelines/build-and-test-iot-anomaly-detection.yaml
@@ -217,7 +217,7 @@ spec:
     - name: TEMPLATE
       value: stage-production-pipelinerun
     - name: PARAMS
-      value: -p TAG=$(tasks.bump-build-version.results.image-tag) -p CONFIGMAP_PREFIX=IOT_ANOMALY -p SOURCE_IMAGE=image-registry.openshift-image-registry.svc:5000/manuela-tst-all/anomaly-detection -p COMPONENT_NAME=iot-anomaly-detection
+      value: -p TAG=$(tasks.bump-build-version-iot-anomaly.results.image-tag) -p CONFIGMAP_PREFIX=IOT_ANOMALY -p SOURCE_IMAGE=image-registry.openshift-image-registry.svc:5000/manuela-tst-all/anomaly-detection -p COMPONENT_NAME=iot-anomaly-detection
 
   - name: cleanup
     taskRef:

--- a/charts/datacenter/pipelines/templates/pipelines/build-and-test-iot-anomaly-detection.yaml
+++ b/charts/datacenter/pipelines/templates/pipelines/build-and-test-iot-anomaly-detection.yaml
@@ -9,6 +9,13 @@ spec:
   - name: github-secret
   - name: quay-secret
   - name: build-artifacts
+  params:
+  - name: DEV_REVISION
+    type: string
+    default: {{ .Values.global.git.dev_revision }}
+  - name: OPS_REVISION
+    type: string
+    default: {{ .Values.global.targetRevision }}
 
   tasks:
   - name: git-clone-dev

--- a/charts/datacenter/pipelines/templates/pipelines/build-and-test-iot-anomaly-detection.yaml
+++ b/charts/datacenter/pipelines/templates/pipelines/build-and-test-iot-anomaly-detection.yaml
@@ -184,8 +184,8 @@ spec:
     - name: revision
       value: $(params.OPS_REVISION)
     - name: argocd-server
-      # datacenter-gitops-server.industrial-edge-datacenter.svc
-      value: "{{ .Values.site.name }}-gitops-server.{{ .Values.global.pattern }}-{{ .Values.site.name }}.svc"
+      value: datacenter-gitops-server.industrial-edge-datacenter.svc
+      #value: "{{ .Values.site.name }}-gitops-server.{{ .Values.global.pattern }}-{{ .Values.site.name }}.svc"
 
  - name: test-all
     taskRef:

--- a/charts/datacenter/pipelines/templates/pipelines/build-and-test-iot-anomaly-detection.yaml
+++ b/charts/datacenter/pipelines/templates/pipelines/build-and-test-iot-anomaly-detection.yaml
@@ -9,6 +9,7 @@ spec:
   - name: github-secret
   - name: quay-secret
   - name: build-artifacts
+  - name: argocd-env-secret
   params:
   - name: DEV_REVISION
     type: string

--- a/charts/datacenter/pipelines/templates/pipelines/build-and-test-iot-anomaly-detection.yaml
+++ b/charts/datacenter/pipelines/templates/pipelines/build-and-test-iot-anomaly-detection.yaml
@@ -184,8 +184,8 @@ spec:
     - name: revision
       value: $(params.OPS_REVISION)
     - name: argocd-server
-      value: datacenter-gitops-server.industrial-edge-datacenter.svc
-      #value: "{{ .Values.site.name }}-gitops-server.{{ .Values.global.pattern }}-{{ .Values.site.name }}.svc"
+      #value: datacenter-gitops-server.industrial-edge-datacenter.svc
+      value: "{{ .Values.site.name }}-gitops-server.{{ .Values.global.pattern }}-{{ .Values.site.name }}.svc"
 
  - name: test-all
     taskRef:

--- a/charts/datacenter/pipelines/templates/pipelines/build-and-test-iot-anomaly-detection.yaml
+++ b/charts/datacenter/pipelines/templates/pipelines/build-and-test-iot-anomaly-detection.yaml
@@ -194,7 +194,7 @@ spec:
       #value: datacenter-gitops-server.industrial-edge-datacenter.svc
       value: "{{ .Values.site.name }}-gitops-server.{{ .Values.global.pattern }}-{{ .Values.site.name }}.svc"
 
- - name: test-all
+  - name: test-all
     taskRef:
       name: tkn
     runAfter:

--- a/charts/datacenter/pipelines/templates/pipelines/build-and-test-iot-consumer.yaml
+++ b/charts/datacenter/pipelines/templates/pipelines/build-and-test-iot-consumer.yaml
@@ -204,7 +204,7 @@ spec:
     - name: TEMPLATE
       value: stage-production-pipelinerun
     - name: PARAMS
-      value: -p TAG=$(tasks.bump-build-version.results.image-tag) -p CONFIGMAP_PREFIX=IOT_CONSUMER -p SOURCE_IMAGE=image-registry.openshift-image-registry.svc:5000/manuela-tst-all/messaging -p COMPONENT_NAME=iot-consumer
+      value: -p TAG=$(tasks.bump-build-version-iot-consumer.results.image-tag) -p CONFIGMAP_PREFIX=IOT_CONSUMER -p SOURCE_IMAGE=image-registry.openshift-image-registry.svc:5000/manuela-tst-all/messaging -p COMPONENT_NAME=iot-consumer
 
   - name: cleanup
     taskRef:

--- a/charts/datacenter/pipelines/templates/pipelines/build-and-test-iot-consumer.yaml
+++ b/charts/datacenter/pipelines/templates/pipelines/build-and-test-iot-consumer.yaml
@@ -173,7 +173,7 @@ spec:
     - name: subdirectory
       value: ops
 
- - name: argocd-sync-application
+  - name: argocd-sync-application
     taskRef:
       name: argocd-sync-and-wait
     runAfter:

--- a/charts/datacenter/pipelines/templates/pipelines/build-and-test-iot-consumer.yaml
+++ b/charts/datacenter/pipelines/templates/pipelines/build-and-test-iot-consumer.yaml
@@ -9,6 +9,7 @@ spec:
   - name: github-secret
   - name: quay-secret
   - name: build-artifacts
+  - name: argocd-env-secret
   params:
   - name: DEV_REVISION
     type: string
@@ -194,6 +195,21 @@ spec:
     - name: argocd-server
       #value: datacenter-gitops-server.industrial-edge-datacenter.svc
       value: "{{ .Values.site.name }}-gitops-server.{{ .Values.global.pattern }}-{{ .Values.site.name }}.svc"
+
+  - name: test-all
+    taskRef:
+      name: tkn
+    runAfter:
+    - argocd-sync-application
+    params:
+    - name: ARGS
+      value:
+      - pipeline
+      - start
+      - test-all
+      - --showlog
+      - --nocolour
+
 
   - name: trigger-staging
     taskRef:

--- a/charts/datacenter/pipelines/templates/pipelines/build-and-test-iot-consumer.yaml
+++ b/charts/datacenter/pipelines/templates/pipelines/build-and-test-iot-consumer.yaml
@@ -185,8 +185,8 @@ spec:
     - name: revision
       value: $(params.OPS_REVISION)
     - name: argocd-server
-      value: datacenter-gitops-server.industrial-edge-datacenter.svc
-      #value: "{{ .Values.site.name }}-gitops-server.{{ .Values.global.pattern }}-{{ .Values.site.name }}.svc"
+      #value: datacenter-gitops-server.industrial-edge-datacenter.svc
+      value: "{{ .Values.site.name }}-gitops-server.{{ .Values.global.pattern }}-{{ .Values.site.name }}.svc"
 
   - name: trigger-staging
     taskRef:

--- a/charts/datacenter/pipelines/templates/pipelines/build-and-test-iot-consumer.yaml
+++ b/charts/datacenter/pipelines/templates/pipelines/build-and-test-iot-consumer.yaml
@@ -1,0 +1,218 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: build-and-test-iot-consumer
+spec:
+  workspaces:
+  - name: gitrepos
+  - name: config
+  - name: github-secret
+  - name: quay-secret
+  - name: build-artifacts
+
+  tasks:
+  - name: git-clone-dev
+    taskRef:
+      name: git-clone-with-tags
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: config
+      workspace: config
+    params:
+    - name: url_configmapkey
+      value: GIT_DEV_REPO_URL
+    - name: revision
+      value: {{ .Values.global.git.dev_revision }}
+    - name: subdirectory
+      value: dev
+    - name: deleteExisting
+      value: "true"
+
+  - name: git-clone-ops
+    taskRef:
+      name: git-clone-with-tags
+    runAfter:
+    - git-clone-dev
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: config
+      workspace: config
+    params:
+    - name: url_configmapkey
+      value: GIT_OPS_REPO_TEST_URL
+    - name: revision
+      value: {{ .Values.global.targetRevision }}
+    - name: subdirectory
+      value: ops
+    - name: deleteExisting
+      value: "true"
+
+  - name: bump-build-version-iot-consumer
+    taskRef:
+      name: bumpversion
+    runAfter:
+    - git-clone-ops
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    params:
+    - name: component_name
+      value: iot-consumer
+    - name: version_file_path
+      value: components/iot-consumer/VERSION
+
+  - name: s2i-build-iot-consumer
+    taskRef:
+      name: s2i
+    runAfter:
+    - bump-build-version-iot-consumer 
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: build-artifacts
+      workspace: build-artifacts
+    params:
+    - name: TLSVERIFY
+      value: "false"
+    - name: PATH_CONTEXT
+      value: components/iot-consumer
+    - name: BUILDER_IMAGE
+      value: registry.access.redhat.com/rhscl/nodejs-10-rhel7
+    - name: TAG
+      value: $(tasks.bump-build-version-iot-consumer.results.image-tag)
+    - name: OUTPUT_IMAGE
+      value: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/messaging
+
+  - name: copy-image-to-remote-registry-iot-consumer
+    taskRef:
+      name: skopeo-copy
+    runAfter: 
+    - s2i-build-iot-consumer
+    workspaces:
+    - name: config
+      workspace: config
+    - name: pushsecret
+      workspace: quay-secret
+    params:
+    - name: TAG
+      value: $(tasks.bump-build-version-iot-consumer.results.image-tag)
+    - name: SOURCE_IMAGE
+      value: image-registry.openshift-image-registry.svc:5000/manuela-tst-all/messaging
+    - name: TARGET_IMAGE_CONFIGMAPKEY
+      value: IOT_CONSUMER_IMAGE
+
+  - name: push-dev-tag
+    taskRef:
+      name: github-push
+    runAfter:
+    - copy-image-to-remote-registry-iot-consumer
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: github-secret
+      workspace: github-secret
+    params:
+    - name: PUSH_FLAGS
+      value: --tags
+
+
+  - name: modify-ops-test-iot-consumer
+    taskRef:
+      name: gitops-imagetag
+    runAfter:
+    - push-dev-tag
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: config
+      workspace: config
+    params:
+    - name: CONFIGMAP_PREFIX
+      value: IOT_CONSUMER
+    - name: ENVIRONMENT
+      value: TEST
+    - name: TAG
+      value: $(tasks.bump-build-version-iot-consumer.results.image-tag)
+    - name: subdirectory
+      value: ops
+
+  - name: commit-ops
+    taskRef:
+      name: git-commit
+    runAfter:
+    - modify-ops-test-iot-consumer
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: config 
+      workspace: config
+    params:
+    - name: subdirectory
+      value: ops
+
+  - name: push-ops
+    taskRef:
+      name: github-push
+    runAfter:
+    - commit-ops
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: github-secret
+      workspace: github-secret
+    params:
+    - name: subdirectory
+      value: ops
+
+ - name: argocd-sync-application
+    taskRef:
+      name: argocd-sync-and-wait
+    runAfter:
+    - push-ops
+    workspaces:
+    - name: argocd-env-secret
+      workspace: argocd-env-secret
+    params:
+    - name: application-name
+      #value: manuela-test-{{ .Values.global.pattern }}-{{ .Values.site.name }}
+      value: manuela-test
+    - name: flags
+      value: --insecure
+    - name: argocd-version
+      value: "v1.5.2"
+    - name: revision
+      value: $(params.OPS_REVISION)
+    - name: argocd-server
+      # datacenter-gitops-server.industrial-edge-datacenter.svc
+      value: "{{ .Values.site.name }}-gitops-server.{{ .Values.global.pattern }}-{{ .Values.site.name }}.svc"
+
+  - name: trigger-staging
+    taskRef:
+      name: openshift-instantiate-template
+    runAfter:
+    - test-all
+    params:
+    - name: TEMPLATE
+      value: stage-production-pipelinerun
+    - name: PARAMS
+      value: -p TAG=$(tasks.bump-build-version.results.image-tag) -p CONFIGMAP_PREFIX=IOT_CONSUMER -p SOURCE_IMAGE=image-registry.openshift-image-registry.svc:5000/manuela-tst-all/messaging -p COMPONENT_NAME=iot-consumer
+
+  - name: cleanup
+    taskRef:
+      name: cleanup
+    runAfter:
+    - trigger-staging
+    workspaces:
+    - name: gitrepos
+      workspace: gitrepos
+    - name: config
+      workspace: config
+    - name: github-secret
+      workspace: github-secret
+    params:
+    - name: subdirectory
+      value: dev
+    - name: COMPONENT_NAME
+      value: iot-consumer

--- a/charts/datacenter/pipelines/templates/pipelines/build-and-test-iot-consumer.yaml
+++ b/charts/datacenter/pipelines/templates/pipelines/build-and-test-iot-consumer.yaml
@@ -9,6 +9,13 @@ spec:
   - name: github-secret
   - name: quay-secret
   - name: build-artifacts
+  params:
+  - name: DEV_REVISION
+    type: string
+    default: {{ .Values.global.git.dev_revision }}
+  - name: OPS_REVISION
+    type: string
+    default: {{ .Values.global.targetRevision }}
 
   tasks:
   - name: git-clone-dev

--- a/charts/datacenter/pipelines/templates/pipelines/build-and-test-iot-consumer.yaml
+++ b/charts/datacenter/pipelines/templates/pipelines/build-and-test-iot-consumer.yaml
@@ -185,8 +185,8 @@ spec:
     - name: revision
       value: $(params.OPS_REVISION)
     - name: argocd-server
-      # datacenter-gitops-server.industrial-edge-datacenter.svc
-      value: "{{ .Values.site.name }}-gitops-server.{{ .Values.global.pattern }}-{{ .Values.site.name }}.svc"
+      value: datacenter-gitops-server.industrial-edge-datacenter.svc
+      #value: "{{ .Values.site.name }}-gitops-server.{{ .Values.global.pattern }}-{{ .Values.site.name }}.svc"
 
   - name: trigger-staging
     taskRef:


### PR DESCRIPTION
This PR adds two new pipelines:
build-and-test-iot-anomaly-detection and build-and-test-iot-consumer.  It builds each, in isolation, then runs the tests on it and opens the PR from the staging-approval branch.

This also adds makefile entries to allow convenient running of these pipelines via ```make build-and-test-iot-anomaly-detection``` and ```make build-and-test-iot-consumer``` respectively.