### PR TITLE
Removed TLS Certificate section from kafka-cluster.yaml

### DIFF
--- a/charts/factory/manuela-data-lake/templates/factory-kafka-cluster/kafka-cluster.yaml
+++ b/charts/factory/manuela-data-lake/templates/factory-kafka-cluster/kafka-cluster.yaml
@@ -24,11 +24,6 @@ spec:
         configuration:
           bootstrap:
             host: bootstrap-factory-lake-central-kafka-cluster.{{ .Values.global.localClusterDomain }}
-        configuration:
-          brokerCertChainAndKey:
-            certificate: tls.crt
-            key: tls.key
-            secretName: kafka-tls-certificate-and-key
     config:
       offsets.topic.replication.factor: 3
       transaction.state.log.min.isr: 2


### PR DESCRIPTION
updated: industrial-edge/charts/factory/manuela-data-lake/templates/factory-kafka-cluster/kafka-cluster.yaml.  I removed the following section from that manifest:
        configuration:
          brokerCertChainAndKey:
            certificate: tls.crt
            key: tls.key
            secretName: kafka-tls-certificate-and-key