### PR TITLE
Remove some duplicated make targets from IE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,6 @@ default: show-secrets show
 	echo "Delegating $* target"
 	make -f common/Makefile $*
 
-load-secrets:
-	common/scripts/ansible-push-vault-secrets.sh
-
 pipeline-setup:
 ifeq ($(BOOTSTRAP),1)
 	helm install $(NAME)-secrets charts/secrets/pipeline-setup $(HELM_OPTS)
@@ -35,17 +32,8 @@ ifeq ($(BOOTSTRAP),1)
 #	make sleep-seed
 endif
 
-vault-init:
-	make -f common/Makefile vault-init
-	echo "Please load your secrets into the vault now"
-
 upgrade: load-secrets
 	make -f common/Makefile upgrade
-
-argosecret:
-	make -f common/Makefile \
-		PATTERN=$(PATTERN) TARGET_NAMESPACE=$(ARGO_TARGET_NAMESPACE) \
-		SECRET_NAME=$(SECRET_NAME) COMPONENT=$(COMPONENT) argosecret
 
 sleep:
 	scripts/sleep-seed.sh


### PR DESCRIPTION
We remove the following targets from the top-level IE Makefile
- load-secrets:
- vault-init:
- argosecret:

Reason is that they are identical to what's in common/Makefile
We can probably also remove the upgrade target, but since it has a
dependency on load-secrets (which the common/Makefile upgrade target
does not have), I am leaving it out now.

This reduces the Makefile complexity a little bit.
