### PR TITLE
Also support oc login in the script to push secrets into the vault (IE-only)

### DIFF
--- a/ansible/roles/bootstrap-industrial-edge/defaults/main.yml
+++ b/ansible/roles/bootstrap-industrial-edge/defaults/main.yml
@@ -14,6 +14,7 @@ values_global: "{{ pattern_repo_dir }}/values-global.yaml"
 
 # KUBECONFIG variable
 kubeconfig: "{{ lookup('env', 'KUBECONFIG') }}"
+kubeconfig_backup: "{{ lookup('env', 'HOME') }}/.kube/config"
 
 # VAULT Variables
 vault_init_file: "{{ pattern_repo_dir }}/common/pattern-vault.init"

--- a/ansible/roles/bootstrap-industrial-edge/tasks/ansible-push-vault-secrets.yaml
+++ b/ansible/roles/bootstrap-industrial-edge/tasks/ansible-push-vault-secrets.yaml
@@ -4,11 +4,20 @@
   register: result
   failed_when: not result.stat.exists
 
-- name: Check that KUBECONFIG is correctly set
-  fail:
-    msg: "KUBECONFIG is not set. Please set it so we can inject the secrets into the cluster's vault"
-  failed_when: kubeconfig is not defined or kubeconfig | length == 0
-  when: not debug | bool
+- name: Check if KUBECONFIG is correctly set
+  debug:
+    msg: "KUBECONFIG is not set, falling back to ~/.kube/config"
+  when: kubeconfig is not defined or kubeconfig | length == 0
+
+- name: Check if ~/.kube/config exists
+  ansible.builtin.stat:
+    path: "{{ kubeconfig_backup }}"
+  register: kubeconfig_result
+
+- name: Fail if both KUBECONFIG and ~/.kube/config do not exist
+  ansible.builtin.fail:
+    msg: "{{ kubeconfig_backup }} not found and KUBECONFIG unset. Bailing out."
+  failed_when: not kubeconfig_result.stat.exists
 
 - name: Parse "{{ values_secret }}"
   ansible.builtin.set_fact:


### PR DESCRIPTION
We first check for ~/.kube/config and if it also does not exist
then we bail out.

There should be no need to set anything else in the playbook as
~/.kube/config is automatically read by the ansible kubernetes.core
collection [1]

Note: This change is for the ansible in IE only. We will drop this once
we move common/ to ansible and rebase IE to use those common/ roles.

[1] https://github.com/ansible-collections/kubernetes.core/blob/main/docs/kubernetes.core.kubectl_connection.rst
