### PR TITLE
Add kubeconform CI testing for IE

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -51,9 +51,18 @@ jobs:
       - name: Run make common-test
         run: |
           make common-test
+
       - name: Run make test
         run: |
           make test
+
       - name: Run make helmlint
         run: |
           make helmlint
+
+      - name: Run make helm kubeconform
+        run: |
+          curl -L -O https://github.com/yannh/kubeconform/releases/download/v0.4.13/kubeconform-linux-amd64.tar.gz
+          tar xf kubeconform-linux-amd64.tar.gz
+          sudo mv -v kubeconform /usr/local/bin
+          make kubeconform

--- a/Makefile
+++ b/Makefile
@@ -72,5 +72,11 @@ test:
 	make -f common/Makefile CHARTS="$(wildcard charts/datacenter/*)" PATTERN_OPTS="-f values-datacenter.yaml" test
 	make -f common/Makefile CHARTS="$(wildcard charts/factory/*)" PATTERN_OPTS="-f values-factory.yaml" test
 
+.PHONY: kubeconform
+KUBECONFORM_SKIP=-skip 'CustomResourceDefinition,Pipeline,Task'
+kubeconform:
+	make -f common/Makefile KUBECONFORM_SKIP="$(KUBECONFORM_SKIP)" CHARTS="$(wildcard charts/datacenter/*)" kubeconform
+	make -f common/Makefile KUBECONFORM_SKIP="$(KUBECONFORM_SKIP)" CHARTS="$(wildcard charts/factory/*)" kubeconform
+
 helmlint:
 	@for t in "$(wildcard charts/datacenter/*)" "$(wildcard charts/factory/*)"; do helm lint $$t; if [ $$? != 0 ]; then exit 1; fi; done


### PR DESCRIPTION
This runs 'make kubeconform' in github actions to validate yaml files.
Example run for IE:

make -f common/Makefile KUBECONFORM_SKIP="-skip 'CustomResourceDefinition,Pipeline,Task'" CHARTS="charts/datacenter/central-s3-store charts/datacenter/external-secrets charts/datacenter/kafka charts/datacenter/manuela-tst charts/datacenter/opendatahub charts/datacenter/pipelines" kubeconform
make[1]: Entering directory '/home/michele/Engineering/cloud-patterns/industrial-edge'
stdin - ConfigMap kafka-to-s3-config is valid
stdin - IntegrationPlatform camel-k is valid
stdin - Integration kafka-to-s3-integration is valid
stdin - ExternalSecret image-registry-credentials is valid
stdin - ExternalSecret git-repo-credentials is valid
stdin - ExternalSecret s3-secret is valid
stdin - PlacementBinding datacenter-secret-s3-placement-binding is valid
stdin - PlacementBinding factory-secret-s3-placement-binding is valid
stdin - PlacementRule datacenter-secret-s3-placement is valid
stdin - PlacementRule factory-secret-s3-placement is valid
stdin - Policy datacenter-secret-s3-policy is valid
stdin - Policy factory-secret-s3-policy is valid
stdin - Kafka kafka-cluster is valid
stdin - ConfigMap machine-sensor-1 is valid
stdin - ConfigMap line-dashboard-configmap is valid
stdin - ConfigMap messaging-configmap is valid
stdin - ConfigMap machine-sensor-2 is valid
stdin - ConfigMap mqtt2kafka-config is valid
stdin - Service line-dashboard is valid
stdin - Service messaging is valid
stdin - Deployment machine-sensor-1 is valid
stdin - Deployment line-dashboard is valid
stdin - Deployment messaging is valid
stdin - Deployment machine-sensor-2 is valid
stdin - ImageStream anomaly-detection is valid
stdin - ImageStream messaging is valid
stdin - ActiveMQArtemis broker-amq-mqtt is valid
stdin - ImageStream line-dashboard is valid
stdin - ImageStream machine-sensor is valid
stdin - IntegrationPlatform camel-k is valid
stdin - Integration mqtt2kafka-integration is valid
stdin - KafkaTopic iot-sensor-sw-temperature is valid
stdin - KafkaTopic iot-sensor-sw-vibration is valid
stdin - Route messaging is valid
stdin - Route line-dashboard is valid
stdin - Route anomaly-detection is valid
stdin - Kafka manuela-kafka-cluster is valid
stdin - Subscription seldon-operator is valid
stdin - SeldonDeployment anomaly-detection is valid
stdin - RoleBinding view is valid
stdin - KfDef opendatahub is valid
stdin - RoleBinding admin is valid
stdin - PersistentVolumeClaim gitrepos-rwo is valid
stdin - build-and-test-iot-anomaly-detection Pipeline skipped
stdin - PersistentVolumeClaim build-artifacts-rwo is valid
stdin - build-and-test-iot-consumer Pipeline skipped
stdin - ConfigMap environment is valid
stdin - RoleBinding admin is valid
stdin - build-base-images Pipeline skipped
stdin - build-and-test Pipeline skipped
stdin - build-iot-anomaly-detection Pipeline skipped
stdin - build-iot-consumer Pipeline skipped
stdin - build-iot-frontend Pipeline skipped
stdin - build-iot-software-sensor Pipeline skipped
stdin - seed-iot-anomaly-detection Pipeline skipped
stdin - seed-iot-consumer Pipeline skipped
stdin - seed-iot-frontend Pipeline skipped
stdin - seed-iot-software-sensor Pipeline skipped
stdin - seed Pipeline skipped
stdin - test-all Pipeline skipped
stdin - stage-production Pipeline skipped
stdin - argocd-sync-and-wait Task skipped
stdin - buildah Task skipped
stdin - bumpversion Task skipped
stdin - fail Task skipped
stdin - cleanup Task skipped
stdin - git-checkout Task skipped
stdin - git-clone-with-tags Task skipped
stdin - git-commit Task skipped
stdin - github-add-pull-request Task skipped
stdin - github-push Task skipped
stdin - mock Task skipped
stdin - gitops-imagetag Task skipped
stdin - openshift-instantiate-template Task skipped
stdin - skopeo-copy Task skipped
stdin - tkn Task skipped
stdin - s2i Task skipped
stdin - Template build-image-bumpversion is valid
stdin - Template build-image-httpd-ionic is valid
stdin - Template build-iot-anomaly-detection is valid
stdin - Template build-image-pushprox is valid
stdin - Template build-iot-consumer is valid
stdin - Template build-iot-frontend is valid
stdin - Template build-iot-software-sensor-quarkus is valid
stdin - Template seed is valid
stdin - Template build-iot-software-sensor is valid
stdin - Template stage-production-pipelinerun is valid
make[1]: Leaving directory '/home/michele/Engineering/cloud-patterns/industrial-edge'
make -f common/Makefile KUBECONFORM_SKIP="-skip 'CustomResourceDefinition,Pipeline,Task'" CHARTS="charts/factory/manuela-data-lake charts/factory/manuela-stormshift" kubeconform
make[1]: Entering directory '/home/michele/Engineering/cloud-patterns/industrial-edge'
stdin - Secret kafka-tls-certificate is valid
stdin - ConfigMap kafka-to-s3-config is valid
stdin - IntegrationPlatform camel-k is valid
stdin - Integration kafka-to-s3-integration is valid
stdin - KafkaMirrorMaker2 factory-to-central is valid
stdin - Kafka kafka-cluster is valid
stdin - ConfigMap mqtt2kafka-config is valid
stdin - ConfigMap messaging-configmap is valid
stdin - ConfigMap machine-sensor-2 is valid
stdin - ConfigMap line-dashboard-configmap is valid
stdin - ConfigMap machine-sensor-1 is valid
stdin - Service line-dashboard is valid
stdin - Service messaging is valid
stdin - Deployment line-dashboard is valid
stdin - Deployment machine-sensor-1 is valid
stdin - Deployment messaging is valid
stdin - Deployment machine-sensor-2 is valid
stdin - ImageStream anomaly-detection is valid
stdin - ImageStream messaging is valid
stdin - ActiveMQArtemis broker-amq-mqtt is valid
stdin - ImageStream line-dashboard is valid
stdin - ImageStream machine-sensor is valid
stdin - IntegrationPlatform camel-k is valid
stdin - Integration mqtt2kafka-integration is valid
stdin - KafkaTopic iot-sensor-sw-temperature is valid
stdin - KafkaTopic iot-sensor-sw-vibration is valid
stdin - Route anomaly-detection is valid
stdin - Route line-dashboard is valid
stdin - Kafka manuela-kafka-cluster is valid
stdin - Route messaging is valid
stdin - SeldonDeployment anomaly-detection is valid
make[1]: Leaving directory '/home/michele/Engineering/cloud-patterns/industrial-edge'

Pipeline and Task jsons need to be skipped due to an openapi2json bug.
Not ideal but still an improvement for now.
