### PR TITLE
Make sure we only bail out when both KUBECONFIG and ~/.kube/config are not set

### DIFF
--- a/ansible/roles/bootstrap-industrial-edge/tasks/ansible-push-vault-secrets.yaml
+++ b/ansible/roles/bootstrap-industrial-edge/tasks/ansible-push-vault-secrets.yaml
@@ -17,7 +17,7 @@
 - name: Fail if both KUBECONFIG and ~/.kube/config do not exist
   ansible.builtin.fail:
     msg: "{{ kubeconfig_backup }} not found and KUBECONFIG unset. Bailing out."
-  failed_when: not kubeconfig_result.stat.exists
+  failed_when: not kubeconfig_result.stat.exists and (kubeconfig is not defined or kubeconfig | length == 0)
 
 - name: Parse "{{ values_secret }}"
   ansible.builtin.set_fact:


### PR DESCRIPTION
In common/ 1d3befcbbaa833abb3553835e252a55eadadb096 we fixed a logic
error around kubeconfig, let's bring that into the IE's ansible role as
well:

  Currently there is an error in the logic there and it bails out when
  ~/.kube/config does not exist even though KUBECONFIG is set. Let's fix
  that
