### PR TITLE
Remove useless exclude: kube-* from ACM policies

### DIFF
--- a/charts/datacenter/external-secrets/templates/datacenter-s3-secret-policy.yaml
+++ b/charts/datacenter/external-secrets/templates/datacenter-s3-secret-policy.yaml
@@ -17,8 +17,6 @@ spec:
           remediationAction: enforce
           severity: med
           namespaceSelector:
-            exclude:
-              - kube-*
             include:
               - default
           object-templates:

--- a/charts/datacenter/external-secrets/templates/factory-s3-secret-policy.yaml
+++ b/charts/datacenter/external-secrets/templates/factory-s3-secret-policy.yaml
@@ -17,8 +17,6 @@ spec:
           remediationAction: enforce
           severity: med
           namespaceSelector:
-            exclude:
-              - kube-*
             include:
               - default
           object-templates:

--- a/tests/datacenter-external-secrets-naked.expected.yaml
+++ b/tests/datacenter-external-secrets-naked.expected.yaml
@@ -146,8 +146,6 @@ spec:
           remediationAction: enforce
           severity: med
           namespaceSelector:
-            exclude:
-              - kube-*
             include:
               - default
           object-templates:
@@ -182,8 +180,6 @@ spec:
           remediationAction: enforce
           severity: med
           namespaceSelector:
-            exclude:
-              - kube-*
             include:
               - default
           object-templates:

--- a/tests/datacenter-external-secrets-normal.expected.yaml
+++ b/tests/datacenter-external-secrets-normal.expected.yaml
@@ -146,8 +146,6 @@ spec:
           remediationAction: enforce
           severity: med
           namespaceSelector:
-            exclude:
-              - kube-*
             include:
               - default
           object-templates:
@@ -182,8 +180,6 @@ spec:
           remediationAction: enforce
           severity: med
           namespaceSelector:
-            exclude:
-              - kube-*
             include:
               - default
           object-templates:


### PR DESCRIPTION
The namespaceSelector example:

  namespaceSelector:
    include: ["default"]
    exclude: ["kube-*"]

shows up in many places in the documentation. Yet it is not particularly
relevant. Full explanation can be found in
https://bugzilla.redhat.com/show_bug.cgi?id=2079393

Let's just drop the exclude, since we already define an include
without a regex, there is no point in excluding anything really.

Tested by redeploying a full multicloud-gitops pattern across
two clusters.
