### PR TITLE
Added lookup for kafka prod secret policy

### DIFF
--- a/charts/datacenter/manuela-data-lake/templates/factory-data-lake-secret-policy.yaml
+++ b/charts/datacenter/manuela-data-lake/templates/factory-data-lake-secret-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
-  name: factory-secret-s3-policy
+  name: factory-secret-data-lake-policy
 spec:
   remediationAction: enforce
   disabled: false
@@ -10,7 +10,7 @@ spec:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
         metadata:
-          name: factory-secret-s3
+          name: factory-secret-data-lake
           annotations:
             apps.open-cluster-management.io/deployables: "secret"
         spec:
@@ -25,22 +25,22 @@ spec:
                 kind: Secret
                 type: Opaque
                 metadata:
-                  name: s3-secret
+                  name: prod-kafka-cluster-cluster-ca-cert
                   namespace: manuela-stormshift-messaging
                 apiVersion: v1
                 data:
-                  application.properties: '{{ `{{hub (lookup "v1" "Secret" "external-secrets" "s3-secret").data.s3Secret hub}}` }}'
+                  ca.crt: '{{ `{{hub index (lookup "v1" "Secret" "manuela-data-lake" "prod-kafka-cluster-cluster-ca-cert").data "ca.crt" hub}}` }}'
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-  name: factory-secret-s3-placement-binding
+  name: factory-secret-data-lake-placement-binding
 placementRef:
-  name: factory-secret-s3-placement
+  name: factory-secret-data-lake-placement
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-  - name: factory-secret-s3-policy
+  - name: factory-secret-data-lake-policy
     kind: Policy
     apiGroup: policy.open-cluster-management.io
 ---
@@ -48,7 +48,7 @@ subjects:
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
-  name: factory-secret-s3-placement
+  name: factory-secret-data-lake-placement
 spec:
   # This will go to all clusters
   clusterConditions:

--- a/tests/datacenter-external-secrets-naked.expected.yaml
+++ b/tests/datacenter-external-secrets-naked.expected.yaml
@@ -82,20 +82,6 @@ subjects:
     kind: Policy
     apiGroup: policy.open-cluster-management.io
 ---
-# Source: external-secrets-install/templates/factory-s3-secret-policy.yaml
-apiVersion: policy.open-cluster-management.io/v1
-kind: PlacementBinding
-metadata:
-  name: factory-secret-s3-placement-binding
-placementRef:
-  name: factory-secret-s3-placement
-  kind: PlacementRule
-  apiGroup: apps.open-cluster-management.io
-subjects:
-  - name: factory-secret-s3-policy
-    kind: Policy
-    apiGroup: policy.open-cluster-management.io
----
 # Source: external-secrets-install/templates/datacenter-s3-secret-policy.yaml
 # We need to run this on any managed cluster but not on the HUB
 apiVersion: apps.open-cluster-management.io/v1
@@ -113,18 +99,6 @@ spec:
         operator: In
         values:
           - 'true'
----
-# Source: external-secrets-install/templates/factory-s3-secret-policy.yaml
-# We need to run this on any managed cluster but not on the HUB
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
-metadata:
-  name: factory-secret-s3-placement
-spec:
-  # This will go to all clusters
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
 ---
 # Source: external-secrets-install/templates/datacenter-s3-secret-policy.yaml
 apiVersion: policy.open-cluster-management.io/v1
@@ -166,40 +140,6 @@ spec:
                 metadata:
                   name: s3-secret
                   namespace: manuela-tst-all
-                apiVersion: v1
-                data:
-                  application.properties: '{{hub (lookup "v1" "Secret" "external-secrets" "s3-secret").data.s3Secret hub}}'
----
-# Source: external-secrets-install/templates/factory-s3-secret-policy.yaml
-apiVersion: policy.open-cluster-management.io/v1
-kind: Policy
-metadata:
-  name: factory-secret-s3-policy
-spec:
-  remediationAction: enforce
-  disabled: false
-  policy-templates:
-    - objectDefinition:
-        apiVersion: policy.open-cluster-management.io/v1
-        kind: ConfigurationPolicy
-        metadata:
-          name: factory-secret-s3
-          annotations:
-            apps.open-cluster-management.io/deployables: "secret"
-        spec:
-          remediationAction: enforce
-          severity: med
-          namespaceSelector:
-            include:
-              - default
-          object-templates:
-            - complianceType: mustonlyhave
-              objectDefinition:
-                kind: Secret
-                type: Opaque
-                metadata:
-                  name: s3-secret
-                  namespace: manuela-stormshift-messaging
                 apiVersion: v1
                 data:
                   application.properties: '{{hub (lookup "v1" "Secret" "external-secrets" "s3-secret").data.s3Secret hub}}'

--- a/tests/datacenter-external-secrets-normal.expected.yaml
+++ b/tests/datacenter-external-secrets-normal.expected.yaml
@@ -82,20 +82,6 @@ subjects:
     kind: Policy
     apiGroup: policy.open-cluster-management.io
 ---
-# Source: external-secrets-install/templates/factory-s3-secret-policy.yaml
-apiVersion: policy.open-cluster-management.io/v1
-kind: PlacementBinding
-metadata:
-  name: factory-secret-s3-placement-binding
-placementRef:
-  name: factory-secret-s3-placement
-  kind: PlacementRule
-  apiGroup: apps.open-cluster-management.io
-subjects:
-  - name: factory-secret-s3-policy
-    kind: Policy
-    apiGroup: policy.open-cluster-management.io
----
 # Source: external-secrets-install/templates/datacenter-s3-secret-policy.yaml
 # We need to run this on any managed cluster but not on the HUB
 apiVersion: apps.open-cluster-management.io/v1
@@ -113,18 +99,6 @@ spec:
         operator: In
         values:
           - 'true'
----
-# Source: external-secrets-install/templates/factory-s3-secret-policy.yaml
-# We need to run this on any managed cluster but not on the HUB
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
-metadata:
-  name: factory-secret-s3-placement
-spec:
-  # This will go to all clusters
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
 ---
 # Source: external-secrets-install/templates/datacenter-s3-secret-policy.yaml
 apiVersion: policy.open-cluster-management.io/v1
@@ -166,40 +140,6 @@ spec:
                 metadata:
                   name: s3-secret
                   namespace: manuela-tst-all
-                apiVersion: v1
-                data:
-                  application.properties: '{{hub (lookup "v1" "Secret" "external-secrets" "s3-secret").data.s3Secret hub}}'
----
-# Source: external-secrets-install/templates/factory-s3-secret-policy.yaml
-apiVersion: policy.open-cluster-management.io/v1
-kind: Policy
-metadata:
-  name: factory-secret-s3-policy
-spec:
-  remediationAction: enforce
-  disabled: false
-  policy-templates:
-    - objectDefinition:
-        apiVersion: policy.open-cluster-management.io/v1
-        kind: ConfigurationPolicy
-        metadata:
-          name: factory-secret-s3
-          annotations:
-            apps.open-cluster-management.io/deployables: "secret"
-        spec:
-          remediationAction: enforce
-          severity: med
-          namespaceSelector:
-            include:
-              - default
-          object-templates:
-            - complianceType: mustonlyhave
-              objectDefinition:
-                kind: Secret
-                type: Opaque
-                metadata:
-                  name: s3-secret
-                  namespace: manuela-stormshift-messaging
                 apiVersion: v1
                 data:
                   application.properties: '{{hub (lookup "v1" "Secret" "external-secrets" "s3-secret").data.s3Secret hub}}'

--- a/tests/datacenter-manuela-data-lake-naked.expected.yaml
+++ b/tests/datacenter-manuela-data-lake-naked.expected.yaml
@@ -191,3 +191,63 @@ spec:
   entityOperator:
     topicOperator: {}
     userOperator: {}
+---
+# Source: central-s3-store/templates/factory-data-lake-secret-policy.yaml
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: factory-secret-data-lake-placement-binding
+placementRef:
+  name: factory-secret-data-lake-placement
+  kind: PlacementRule
+  apiGroup: apps.open-cluster-management.io
+subjects:
+  - name: factory-secret-data-lake-policy
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
+---
+# Source: central-s3-store/templates/factory-data-lake-secret-policy.yaml
+# We need to run this on any managed cluster but not on the HUB
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: factory-secret-data-lake-placement
+spec:
+  # This will go to all clusters
+  clusterConditions:
+    - status: 'True'
+      type: ManagedClusterConditionAvailable
+---
+# Source: central-s3-store/templates/factory-data-lake-secret-policy.yaml
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: factory-secret-data-lake-policy
+spec:
+  remediationAction: enforce
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: factory-secret-data-lake
+          annotations:
+            apps.open-cluster-management.io/deployables: "secret"
+        spec:
+          remediationAction: enforce
+          severity: med
+          namespaceSelector:
+            include:
+              - default
+          object-templates:
+            - complianceType: mustonlyhave
+              objectDefinition:
+                kind: Secret
+                type: Opaque
+                metadata:
+                  name: prod-kafka-cluster-cluster-ca-cert
+                  namespace: manuela-stormshift-messaging
+                apiVersion: v1
+                data:
+                  ca.crt: '{{hub index (lookup "v1" "Secret" "manuela-data-lake" "prod-kafka-cluster-cluster-ca-cert").data "ca.crt" hub}}'

--- a/tests/datacenter-manuela-data-lake-normal.expected.yaml
+++ b/tests/datacenter-manuela-data-lake-normal.expected.yaml
@@ -191,3 +191,63 @@ spec:
   entityOperator:
     topicOperator: {}
     userOperator: {}
+---
+# Source: central-s3-store/templates/factory-data-lake-secret-policy.yaml
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: factory-secret-data-lake-placement-binding
+placementRef:
+  name: factory-secret-data-lake-placement
+  kind: PlacementRule
+  apiGroup: apps.open-cluster-management.io
+subjects:
+  - name: factory-secret-data-lake-policy
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
+---
+# Source: central-s3-store/templates/factory-data-lake-secret-policy.yaml
+# We need to run this on any managed cluster but not on the HUB
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: factory-secret-data-lake-placement
+spec:
+  # This will go to all clusters
+  clusterConditions:
+    - status: 'True'
+      type: ManagedClusterConditionAvailable
+---
+# Source: central-s3-store/templates/factory-data-lake-secret-policy.yaml
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: factory-secret-data-lake-policy
+spec:
+  remediationAction: enforce
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: factory-secret-data-lake
+          annotations:
+            apps.open-cluster-management.io/deployables: "secret"
+        spec:
+          remediationAction: enforce
+          severity: med
+          namespaceSelector:
+            include:
+              - default
+          object-templates:
+            - complianceType: mustonlyhave
+              objectDefinition:
+                kind: Secret
+                type: Opaque
+                metadata:
+                  name: prod-kafka-cluster-cluster-ca-cert
+                  namespace: manuela-stormshift-messaging
+                apiVersion: v1
+                data:
+                  ca.crt: '{{hub index (lookup "v1" "Secret" "manuela-data-lake" "prod-kafka-cluster-cluster-ca-cert").data "ca.crt" hub}}'


### PR DESCRIPTION
Update to the ACM policy to copy production kafka ca cert to the manuela-stormshift-messaging namespace on a factory cluster.