### PR TITLE
Bootstrap ansible update

### DIFF
--- a/ansible/roles/bootstrap-industrial-edge/tasks/ansible-push-vault-secrets.yaml
+++ b/ansible/roles/bootstrap-industrial-edge/tasks/ansible-push-vault-secrets.yaml
@@ -1,115 +1,174 @@
-- name: Check for existence of "{{ values_secret }}"
-  ansible.builtin.stat:
-    path: "{{ values_secret }}"
-  register: result
-  failed_when: not result.stat.exists
-
-- name: Check if KUBECONFIG is correctly set
-  debug:
-    msg: "KUBECONFIG is not set, falling back to ~/.kube/config"
-  when: kubeconfig is not defined or kubeconfig | length == 0
-
-- name: Check if ~/.kube/config exists
-  ansible.builtin.stat:
-    path: "{{ kubeconfig_backup }}"
-  register: kubeconfig_result
-
-- name: Fail if both KUBECONFIG and ~/.kube/config do not exist
-  ansible.builtin.fail:
-    msg: "{{ kubeconfig_backup }} not found and KUBECONFIG unset. Bailing out."
-  failed_when: not kubeconfig_result.stat.exists and (kubeconfig is not defined or kubeconfig | length == 0)
-
-- name: Parse "{{ values_secret }}"
-  ansible.builtin.set_fact:
-    all_values: "{{ lookup('file', values_secret) | from_yaml }}"
-
-- name: Set secrets fact
-  ansible.builtin.set_fact:
-    secrets: "{{ all_values['secrets'] }}"
-
-- name: Verify we have any secrets at all
-  ansible.builtin.fail:
-    msg: "Was not able to parse any secrets from file {{ values_secret }}: {{ all_values }}"
-  failed_when:
-    secrets is not defined or secrets | length == 0
-
-# Detect here if we have only the following two keys under a password
-# s3.accessKey: <accessKey>
-# s3.secretKey: <secret key>
-# If we do, then detect it and calculate the b64 s3Secret token
-# Note: the vars: line is due to https://github.com/ansible/ansible/issues/40239
-- name: Check if any of the passwords has only s3.[accessKey,secretKey] and generate the combined s3Secret in that case
-  ansible.builtin.set_fact:
-    s3keys: "{{ s3keys | default({}) | combine({ item.key: {'s3Secret': s3secret | b64encode } }) }}"
+#!/usr/bin/env ansible-playbook
+- name: Secret injection of validated-patterns
+  hosts: localhost
+  connection: local
+  gather_facts: no
   vars:
-    s3secret: "{{ 's3.accessKey: ' + item.value['s3.accessKey'] + '\ns3.secretKey: ' + item.value['s3.secretKey'] }}"
-  when:
-    - '"s3.accessKey" in item.value.keys()'
-    - '"s3.secretKey" in item.value.keys()'
-    - '"s3Secret" not in item.value.keys()'
-  loop:
-    "{{ secrets | dict2items }}"
-  loop_control:
-    label: "{{ item.key }}"
+    kubeconfig: "{{ lookup('env', 'KUBECONFIG') }}"
+    kubeconfig_backup: "{{ lookup('env', 'HOME') }}/.kube/config"
+    values_secret: "{{ lookup('env', 'HOME') }}/values-secret.yaml"
+    vault_ns: "vault"
+    vault_pod: "vault-0"
+    vault_path: "secret/hub"
+    debug: False
 
-- name: Merge any s3Secret into the secrets dictionary if we have any
-  ansible.builtin.set_fact:
-    secrets: "{{ secrets | combine(s3keys) }}"
-  when:
-    s3keys is defined and s3keys | length > 0
+  tasks:
+  - name: Check if the kubernetes python module is usable from ansible
+    ansible.builtin.shell: "{{ ansible_python_interpreter }} -c 'import kubernetes'"
 
-- name: Check for vault namespace
-  kubernetes.core.k8s_info:
-    kind: Namespace
-    name: "{{ vault_ns }}"
-  register: vault_ns_rc
-  failed_when: vault_ns_rc.resources | length == 0
-  when: not debug | bool
+  - name: Check for existence of "{{ values_secret }}"
+    ansible.builtin.stat:
+      path: "{{ values_secret }}"
+    register: result
+    failed_when: not result.stat.exists
 
-- name: Check if the vault pod is present
-  kubernetes.core.k8s_info:
-    kind: Pod
-    namespace: "{{ vault_ns }}"
-    name: "{{ vault_pod }}"
-  register: vault_pod_rc
-  failed_when: vault_pod_rc.resources | length == 0
-  when: not debug | bool
+  - name: Check if KUBECONFIG is correctly set
+    debug:
+      msg: "KUBECONFIG is not set, falling back to ~/.kube/config"
+    when: kubeconfig is not defined or kubeconfig | length == 0
 
-# vault status returns 1 on error and 2 on sealed
-# so we can bail out when sealed
-- name: Check if the vault is unsealed
-  kubernetes.core.k8s_exec:
-    namespace: "{{ vault_ns }}"
-    pod: "{{ vault_pod }}"
-    command: vault status
-  register: vault_status
-  failed_when: vault_status.rc|int == 1
-  when: not debug | bool
+  - name: Check if ~/.kube/config exists
+    ansible.builtin.stat:
+      path: "{{ kubeconfig_backup }}"
+    register: kubeconfig_result
 
-- name: Check vault status return
-  ansible.builtin.fail:
-    msg: The vault is still sealed. Please run "make vault-init" first with KUBECONFIG pointing to the HUB cluster
-  when:
-    - not debug | bool
-    - vault_status.rc | int > 0
+  - name: Fail if both KUBECONFIG and ~/.kube/config do not exist
+    ansible.builtin.fail:
+      msg: "{{ kubeconfig_backup }} not found and KUBECONFIG unset. Bailing out."
+    failed_when: not kubeconfig_result.stat.exists and (kubeconfig is not defined or kubeconfig | length == 0)
 
-- name: Debug
-  debug:
-    msg: "vault kv put {{ vault_path }}/{{ item.key }} -> {{ item.value.keys() | zip(item.value.values()) | map('join', '=') | list | join(' ')}}"
-  loop:
-    "{{ secrets | dict2items }}"
-  loop_control:
-    label: "{{ item.key }}"
-  when: debug | bool
+  - name: Parse "{{ values_secret }}"
+    ansible.builtin.set_fact:
+      all_values: "{{ lookup('file', values_secret) | from_yaml }}"
 
-- name: Add the actual secrets to the vault
-  kubernetes.core.k8s_exec:
-    namespace: "{{ vault_ns }}"
-    pod: "{{ vault_pod }}"
-    command: |
-      sh -c "vault kv put {{ vault_path }}/{{ item.key }} {{ item.value.keys() | zip(item.value.values()) | map('join', '=') | list | join(' ')}}"
-  loop:
-    "{{ secrets | dict2items }}"
-  loop_control:
-    label: "{{ item.key }}"
-  when: not debug | bool
+  - name: Set secrets fact
+    ansible.builtin.set_fact:
+      secrets: "{{ all_values['secrets'] }}"
+
+  - name: Verify we have any secrets at all
+    ansible.builtin.fail:
+      msg: "Was not able to parse any secrets from file {{ values_secret }}: {{ all_values }}"
+    failed_when:
+      secrets is not defined or secrets | length == 0
+
+  - name: Check the value-secret.yaml file for errors
+    ansible.builtin.fail:
+      msg: >
+        "{{ item }}" is not properly formatted. Each key under 'secrets:'
+        needs to point to a dictionary of key, value pairs. See values-secret.yaml.template.
+    when: >
+      item.key | length == 0 or
+      item.value is not mapping
+    loop:
+      "{{ secrets | dict2items }}"
+    loop_control:
+      label: "{{ item.key }}"
+
+  # Detect here if we have only the following two keys under a password
+  # s3.accessKey: <accessKey>
+  # s3.secretKey: <secret key>
+  # If we do, then detect it and calculate the b64 s3Secret token
+  # Note: the vars: line is due to https://github.com/ansible/ansible/issues/40239
+  - name: Check if any of the passwords has only s3.[accessKey,secretKey] and generate the combined s3Secret in that case
+    ansible.builtin.set_fact:
+      s3keys: "{{ s3keys | default({}) | combine({ item.key: {'s3Secret': s3secret | b64encode } }) }}"
+    vars:
+      s3secret: "{{ 's3.accessKey: ' + item.value['s3.accessKey'] + '\ns3.secretKey: ' + item.value['s3.secretKey'] }}"
+    when:
+      - '"s3.accessKey" in item.value.keys()'
+      - '"s3.secretKey" in item.value.keys()'
+      - '"s3Secret" not in item.value.keys()'
+    loop:
+      "{{ secrets | dict2items }}"
+    loop_control:
+      label: "{{ item.key }}"
+
+  - name: Merge any s3Secret into the secrets dictionary if we have any
+    ansible.builtin.set_fact:
+      secrets: "{{ secrets | combine(s3keys) }}"
+    when:
+      s3keys is defined and s3keys | length > 0
+
+  - name: Check for vault namespace
+    kubernetes.core.k8s_info:
+      kind: Namespace
+      name: "{{ vault_ns }}"
+    register: vault_ns_rc
+    failed_when: vault_ns_rc.resources | length == 0
+    when: not debug | bool
+
+  - name: Check if the vault pod is present
+    kubernetes.core.k8s_info:
+      kind: Pod
+      namespace: "{{ vault_ns }}"
+      name: "{{ vault_pod }}"
+    register: vault_pod_rc
+    failed_when: vault_pod_rc.resources | length == 0
+    when: not debug | bool
+
+  # vault status returns 1 on error and 2 on sealed
+  # so we can bail out when sealed
+  - name: Check if the vault is unsealed
+    kubernetes.core.k8s_exec:
+      namespace: "{{ vault_ns }}"
+      pod: "{{ vault_pod }}"
+      command: vault status
+    register: vault_status
+    failed_when: vault_status.rc|int == 1
+    when: not debug | bool
+
+  - name: Check vault status return
+    ansible.builtin.fail:
+      msg: The vault is still sealed. Please run "make vault-init" first with KUBECONFIG pointing to the HUB cluster
+    when:
+      - not debug | bool
+      - vault_status.rc | int > 0
+
+# The values-secret.yaml file is in the fairly loose form of:
+# secrets:
+#   group1:
+#     key1: value1
+#     key2: value2
+#   group2:
+#     key1: valueA
+#     key4: valueC
+# The above will generate:
+# vault kv put 'secret/hub/group1' key1='value1' key2='value2'
+# vault kv put 'secret/hub/group2' key1='valueA' key4='valueC'
+# Below we loop on the top level keys (group1, group2) and for each
+# sub-top-level key (key1, key2) we create a single 'key1=value1 key2=value2' string
+#
+# Special note is to be given to the regex_replace which is run against each value aka password:
+# A. The need for it is to quote the passwords
+# B. Since it needs to cater to multiline strings (certs) and ansible offers no way
+#    to specify re.DOTALL and re.MULTILINE we need to use (?ms) at the beginning
+#    See https://docs.python.org/3/library/re.html and (?aiLmsux) section
+#    and https://github.com/ansible/ansible/blob/devel/lib/ansible/plugins/filter/core.py#L124
+# C. The \\A and \\Z match the beginning and end of a string (in case of multiline strings
+#    do not want to match every line)
+  - name: Set vault commands fact
+    ansible.builtin.set_fact:
+      vault_cmds: "{{ vault_cmds | default({}) | combine({ item.key: vault_cmd}) }}"
+    vars:
+      vault_cmd: "vault kv put '{{ vault_path }}/{{ item.key }}' {{ item.value.keys() | zip(item.value.values() | map('regex_replace', '(?ms)\\A(.*)\\Z', \"'\\1'\")) | map('join', '=') | list | join(' ') }}"
+    loop:
+      "{{ secrets | dict2items }}"
+    loop_control:
+      label: "{{ item.key }}"
+
+  - name: Debug vault commands
+    ansible.builtin.debug:
+      msg: "{{ vault_cmds }}"
+    when: debug | bool
+
+  - name: Add the actual secrets to the vault
+    kubernetes.core.k8s_exec:
+      namespace: "{{ vault_ns }}"
+      pod: "{{ vault_pod }}"
+      command: |
+        sh -c "{{ item.value }}"
+    loop:
+      "{{ vault_cmds | dict2items }}"
+    loop_control:
+      label: "{{ item.key }}"
+    when: not debug | bool

--- a/ansible/roles/bootstrap-industrial-edge/tasks/ansible-push-vault-secrets.yaml
+++ b/ansible/roles/bootstrap-industrial-edge/tasks/ansible-push-vault-secrets.yaml
@@ -1,128 +1,113 @@
-#!/usr/bin/env ansible-playbook
-- name: Secret injection of validated-patterns
-  hosts: localhost
-  connection: local
-  gather_facts: no
+- name: Check if the kubernetes python module is usable from ansible
+  ansible.builtin.shell: "{{ ansible_python_interpreter }} -c 'import kubernetes'"
+
+- name: Check for existence of "{{ values_secret }}"
+  ansible.builtin.stat:
+    path: "{{ values_secret }}"
+  register: result
+  failed_when: not result.stat.exists
+
+- name: Check if KUBECONFIG is correctly set
+  debug:
+    msg: "KUBECONFIG is not set, falling back to ~/.kube/config"
+  when: kubeconfig is not defined or kubeconfig | length == 0
+
+- name: Check if ~/.kube/config exists
+  ansible.builtin.stat:
+    path: "{{ kubeconfig_backup }}"
+  register: kubeconfig_result
+
+- name: Fail if both KUBECONFIG and ~/.kube/config do not exist
+  ansible.builtin.fail:
+    msg: "{{ kubeconfig_backup }} not found and KUBECONFIG unset. Bailing out."
+  failed_when: not kubeconfig_result.stat.exists and (kubeconfig is not defined or kubeconfig | length == 0)
+
+- name: Parse "{{ values_secret }}"
+  ansible.builtin.set_fact:
+    all_values: "{{ lookup('file', values_secret) | from_yaml }}"
+
+- name: Set secrets fact
+  ansible.builtin.set_fact:
+    secrets: "{{ all_values['secrets'] }}"
+
+- name: Verify we have any secrets at all
+  ansible.builtin.fail:
+    msg: "Was not able to parse any secrets from file {{ values_secret }}: {{ all_values }}"
+  failed_when:
+    secrets is not defined or secrets | length == 0
+
+- name: Check the value-secret.yaml file for errors
+  ansible.builtin.fail:
+    msg: >
+      "{{ item }}" is not properly formatted. Each key under 'secrets:'
+      needs to point to a dictionary of key, value pairs. See values-secret.yaml.template.
+  when: >
+    item.key | length == 0 or
+    item.value is not mapping
+  loop:
+    "{{ secrets | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+
+# Detect here if we have only the following two keys under a password
+# s3.accessKey: <accessKey>
+# s3.secretKey: <secret key>
+# If we do, then detect it and calculate the b64 s3Secret token
+# Note: the vars: line is due to https://github.com/ansible/ansible/issues/40239
+- name: Check if any of the passwords has only s3.[accessKey,secretKey] and generate the combined s3Secret in that case
+  ansible.builtin.set_fact:
+    s3keys: "{{ s3keys | default({}) | combine({ item.key: {'s3Secret': s3secret | b64encode } }) }}"
   vars:
-    kubeconfig: "{{ lookup('env', 'KUBECONFIG') }}"
-    kubeconfig_backup: "{{ lookup('env', 'HOME') }}/.kube/config"
-    values_secret: "{{ lookup('env', 'HOME') }}/values-secret.yaml"
-    vault_ns: "vault"
-    vault_pod: "vault-0"
-    vault_path: "secret/hub"
-    debug: False
+    s3secret: "{{ 's3.accessKey: ' + item.value['s3.accessKey'] + '\ns3.secretKey: ' + item.value['s3.secretKey'] }}"
+  when:
+    - '"s3.accessKey" in item.value.keys()'
+    - '"s3.secretKey" in item.value.keys()'
+    - '"s3Secret" not in item.value.keys()'
+  loop:
+    "{{ secrets | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
 
-  tasks:
-  - name: Check if the kubernetes python module is usable from ansible
-    ansible.builtin.shell: "{{ ansible_python_interpreter }} -c 'import kubernetes'"
+- name: Merge any s3Secret into the secrets dictionary if we have any
+  ansible.builtin.set_fact:
+    secrets: "{{ secrets | combine(s3keys) }}"
+  when:
+    s3keys is defined and s3keys | length > 0
 
-  - name: Check for existence of "{{ values_secret }}"
-    ansible.builtin.stat:
-      path: "{{ values_secret }}"
-    register: result
-    failed_when: not result.stat.exists
+- name: Check for vault namespace
+  kubernetes.core.k8s_info:
+    kind: Namespace
+    name: "{{ vault_ns }}"
+  register: vault_ns_rc
+  failed_when: vault_ns_rc.resources | length == 0
+  when: not debug | bool
 
-  - name: Check if KUBECONFIG is correctly set
-    debug:
-      msg: "KUBECONFIG is not set, falling back to ~/.kube/config"
-    when: kubeconfig is not defined or kubeconfig | length == 0
+- name: Check if the vault pod is present
+  kubernetes.core.k8s_info:
+    kind: Pod
+    namespace: "{{ vault_ns }}"
+    name: "{{ vault_pod }}"
+  register: vault_pod_rc
+  failed_when: vault_pod_rc.resources | length == 0
+  when: not debug | bool
 
-  - name: Check if ~/.kube/config exists
-    ansible.builtin.stat:
-      path: "{{ kubeconfig_backup }}"
-    register: kubeconfig_result
+# vault status returns 1 on error and 2 on sealed
+# so we can bail out when sealed
+- name: Check if the vault is unsealed
+  kubernetes.core.k8s_exec:
+    namespace: "{{ vault_ns }}"
+    pod: "{{ vault_pod }}"
+    command: vault status
+  register: vault_status
+  failed_when: vault_status.rc|int == 1
+  when: not debug | bool
 
-  - name: Fail if both KUBECONFIG and ~/.kube/config do not exist
-    ansible.builtin.fail:
-      msg: "{{ kubeconfig_backup }} not found and KUBECONFIG unset. Bailing out."
-    failed_when: not kubeconfig_result.stat.exists and (kubeconfig is not defined or kubeconfig | length == 0)
-
-  - name: Parse "{{ values_secret }}"
-    ansible.builtin.set_fact:
-      all_values: "{{ lookup('file', values_secret) | from_yaml }}"
-
-  - name: Set secrets fact
-    ansible.builtin.set_fact:
-      secrets: "{{ all_values['secrets'] }}"
-
-  - name: Verify we have any secrets at all
-    ansible.builtin.fail:
-      msg: "Was not able to parse any secrets from file {{ values_secret }}: {{ all_values }}"
-    failed_when:
-      secrets is not defined or secrets | length == 0
-
-  - name: Check the value-secret.yaml file for errors
-    ansible.builtin.fail:
-      msg: >
-        "{{ item }}" is not properly formatted. Each key under 'secrets:'
-        needs to point to a dictionary of key, value pairs. See values-secret.yaml.template.
-    when: >
-      item.key | length == 0 or
-      item.value is not mapping
-    loop:
-      "{{ secrets | dict2items }}"
-    loop_control:
-      label: "{{ item.key }}"
-
-  # Detect here if we have only the following two keys under a password
-  # s3.accessKey: <accessKey>
-  # s3.secretKey: <secret key>
-  # If we do, then detect it and calculate the b64 s3Secret token
-  # Note: the vars: line is due to https://github.com/ansible/ansible/issues/40239
-  - name: Check if any of the passwords has only s3.[accessKey,secretKey] and generate the combined s3Secret in that case
-    ansible.builtin.set_fact:
-      s3keys: "{{ s3keys | default({}) | combine({ item.key: {'s3Secret': s3secret | b64encode } }) }}"
-    vars:
-      s3secret: "{{ 's3.accessKey: ' + item.value['s3.accessKey'] + '\ns3.secretKey: ' + item.value['s3.secretKey'] }}"
-    when:
-      - '"s3.accessKey" in item.value.keys()'
-      - '"s3.secretKey" in item.value.keys()'
-      - '"s3Secret" not in item.value.keys()'
-    loop:
-      "{{ secrets | dict2items }}"
-    loop_control:
-      label: "{{ item.key }}"
-
-  - name: Merge any s3Secret into the secrets dictionary if we have any
-    ansible.builtin.set_fact:
-      secrets: "{{ secrets | combine(s3keys) }}"
-    when:
-      s3keys is defined and s3keys | length > 0
-
-  - name: Check for vault namespace
-    kubernetes.core.k8s_info:
-      kind: Namespace
-      name: "{{ vault_ns }}"
-    register: vault_ns_rc
-    failed_when: vault_ns_rc.resources | length == 0
-    when: not debug | bool
-
-  - name: Check if the vault pod is present
-    kubernetes.core.k8s_info:
-      kind: Pod
-      namespace: "{{ vault_ns }}"
-      name: "{{ vault_pod }}"
-    register: vault_pod_rc
-    failed_when: vault_pod_rc.resources | length == 0
-    when: not debug | bool
-
-  # vault status returns 1 on error and 2 on sealed
-  # so we can bail out when sealed
-  - name: Check if the vault is unsealed
-    kubernetes.core.k8s_exec:
-      namespace: "{{ vault_ns }}"
-      pod: "{{ vault_pod }}"
-      command: vault status
-    register: vault_status
-    failed_when: vault_status.rc|int == 1
-    when: not debug | bool
-
-  - name: Check vault status return
-    ansible.builtin.fail:
-      msg: The vault is still sealed. Please run "make vault-init" first with KUBECONFIG pointing to the HUB cluster
-    when:
-      - not debug | bool
-      - vault_status.rc | int > 0
+- name: Check vault status return
+  ansible.builtin.fail:
+    msg: The vault is still sealed. Please run "make vault-init" first with KUBECONFIG pointing to the HUB cluster
+  when:
+    - not debug | bool
+    - vault_status.rc | int > 0
 
 # The values-secret.yaml file is in the fairly loose form of:
 # secrets:
@@ -146,29 +131,29 @@
 #    and https://github.com/ansible/ansible/blob/devel/lib/ansible/plugins/filter/core.py#L124
 # C. The \\A and \\Z match the beginning and end of a string (in case of multiline strings
 #    do not want to match every line)
-  - name: Set vault commands fact
-    ansible.builtin.set_fact:
-      vault_cmds: "{{ vault_cmds | default({}) | combine({ item.key: vault_cmd}) }}"
-    vars:
-      vault_cmd: "vault kv put '{{ vault_path }}/{{ item.key }}' {{ item.value.keys() | zip(item.value.values() | map('regex_replace', '(?ms)\\A(.*)\\Z', \"'\\1'\")) | map('join', '=') | list | join(' ') }}"
-    loop:
-      "{{ secrets | dict2items }}"
-    loop_control:
-      label: "{{ item.key }}"
+- name: Set vault commands fact
+  ansible.builtin.set_fact:
+    vault_cmds: "{{ vault_cmds | default({}) | combine({ item.key: vault_cmd}) }}"
+  vars:
+    vault_cmd: "vault kv put '{{ vault_path }}/{{ item.key }}' {{ item.value.keys() | zip(item.value.values() | map('regex_replace', '(?ms)\\A(.*)\\Z', \"'\\1'\")) | map('join', '=') | list | join(' ') }}"
+  loop:
+    "{{ secrets | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
 
-  - name: Debug vault commands
-    ansible.builtin.debug:
-      msg: "{{ vault_cmds }}"
-    when: debug | bool
+- name: Debug vault commands
+  ansible.builtin.debug:
+    msg: "{{ vault_cmds }}"
+  when: debug | bool
 
-  - name: Add the actual secrets to the vault
-    kubernetes.core.k8s_exec:
-      namespace: "{{ vault_ns }}"
-      pod: "{{ vault_pod }}"
-      command: |
-        sh -c "{{ item.value }}"
-    loop:
-      "{{ vault_cmds | dict2items }}"
-    loop_control:
-      label: "{{ item.key }}"
-    when: not debug | bool
+- name: Add the actual secrets to the vault
+  kubernetes.core.k8s_exec:
+    namespace: "{{ vault_ns }}"
+    pod: "{{ vault_pod }}"
+    command: |
+      sh -c "{{ item.value }}"
+  loop:
+    "{{ vault_cmds | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+  when: not debug | bool

--- a/charts/datacenter/manuela-data-lake/templates/factory-data-lake-secret-policy.yaml
+++ b/charts/datacenter/manuela-data-lake/templates/factory-data-lake-secret-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
-  name: factory-secret-s3-policy
+  name: factory-secret-data-lake-policy
 spec:
   remediationAction: enforce
   disabled: false
@@ -10,7 +10,7 @@ spec:
         apiVersion: policy.open-cluster-management.io/v1
         kind: ConfigurationPolicy
         metadata:
-          name: factory-secret-s3
+          name: factory-secret-data-lake
           annotations:
             apps.open-cluster-management.io/deployables: "secret"
         spec:
@@ -25,22 +25,22 @@ spec:
                 kind: Secret
                 type: Opaque
                 metadata:
-                  name: s3-secret
+                  name: prod-kafka-cluster-cluster-ca-cert
                   namespace: manuela-stormshift-messaging
                 apiVersion: v1
                 data:
-                  application.properties: '{{ `{{hub (lookup "v1" "Secret" "external-secrets" "s3-secret").data.s3Secret hub}}` }}'
+                  ca.crt: '{{ `{{hub index (lookup "v1" "Secret" "manuela-data-lake" "prod-kafka-cluster-cluster-ca-cert").data "ca.crt" hub}}` }}'
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
-  name: factory-secret-s3-placement-binding
+  name: factory-secret-data-lake-placement-binding
 placementRef:
-  name: factory-secret-s3-placement
+  name: factory-secret-data-lake-placement
   kind: PlacementRule
   apiGroup: apps.open-cluster-management.io
 subjects:
-  - name: factory-secret-s3-policy
+  - name: factory-secret-data-lake-policy
     kind: Policy
     apiGroup: policy.open-cluster-management.io
 ---
@@ -48,7 +48,7 @@ subjects:
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
-  name: factory-secret-s3-placement
+  name: factory-secret-data-lake-placement
 spec:
   # This will go to all clusters
   clusterConditions:

--- a/tests/datacenter-external-secrets-naked.expected.yaml
+++ b/tests/datacenter-external-secrets-naked.expected.yaml
@@ -82,20 +82,6 @@ subjects:
     kind: Policy
     apiGroup: policy.open-cluster-management.io
 ---
-# Source: external-secrets-install/templates/factory-s3-secret-policy.yaml
-apiVersion: policy.open-cluster-management.io/v1
-kind: PlacementBinding
-metadata:
-  name: factory-secret-s3-placement-binding
-placementRef:
-  name: factory-secret-s3-placement
-  kind: PlacementRule
-  apiGroup: apps.open-cluster-management.io
-subjects:
-  - name: factory-secret-s3-policy
-    kind: Policy
-    apiGroup: policy.open-cluster-management.io
----
 # Source: external-secrets-install/templates/datacenter-s3-secret-policy.yaml
 # We need to run this on any managed cluster but not on the HUB
 apiVersion: apps.open-cluster-management.io/v1
@@ -113,18 +99,6 @@ spec:
         operator: In
         values:
           - 'true'
----
-# Source: external-secrets-install/templates/factory-s3-secret-policy.yaml
-# We need to run this on any managed cluster but not on the HUB
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
-metadata:
-  name: factory-secret-s3-placement
-spec:
-  # This will go to all clusters
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
 ---
 # Source: external-secrets-install/templates/datacenter-s3-secret-policy.yaml
 apiVersion: policy.open-cluster-management.io/v1
@@ -166,40 +140,6 @@ spec:
                 metadata:
                   name: s3-secret
                   namespace: manuela-tst-all
-                apiVersion: v1
-                data:
-                  application.properties: '{{hub (lookup "v1" "Secret" "external-secrets" "s3-secret").data.s3Secret hub}}'
----
-# Source: external-secrets-install/templates/factory-s3-secret-policy.yaml
-apiVersion: policy.open-cluster-management.io/v1
-kind: Policy
-metadata:
-  name: factory-secret-s3-policy
-spec:
-  remediationAction: enforce
-  disabled: false
-  policy-templates:
-    - objectDefinition:
-        apiVersion: policy.open-cluster-management.io/v1
-        kind: ConfigurationPolicy
-        metadata:
-          name: factory-secret-s3
-          annotations:
-            apps.open-cluster-management.io/deployables: "secret"
-        spec:
-          remediationAction: enforce
-          severity: med
-          namespaceSelector:
-            include:
-              - default
-          object-templates:
-            - complianceType: mustonlyhave
-              objectDefinition:
-                kind: Secret
-                type: Opaque
-                metadata:
-                  name: s3-secret
-                  namespace: manuela-stormshift-messaging
                 apiVersion: v1
                 data:
                   application.properties: '{{hub (lookup "v1" "Secret" "external-secrets" "s3-secret").data.s3Secret hub}}'

--- a/tests/datacenter-external-secrets-normal.expected.yaml
+++ b/tests/datacenter-external-secrets-normal.expected.yaml
@@ -82,20 +82,6 @@ subjects:
     kind: Policy
     apiGroup: policy.open-cluster-management.io
 ---
-# Source: external-secrets-install/templates/factory-s3-secret-policy.yaml
-apiVersion: policy.open-cluster-management.io/v1
-kind: PlacementBinding
-metadata:
-  name: factory-secret-s3-placement-binding
-placementRef:
-  name: factory-secret-s3-placement
-  kind: PlacementRule
-  apiGroup: apps.open-cluster-management.io
-subjects:
-  - name: factory-secret-s3-policy
-    kind: Policy
-    apiGroup: policy.open-cluster-management.io
----
 # Source: external-secrets-install/templates/datacenter-s3-secret-policy.yaml
 # We need to run this on any managed cluster but not on the HUB
 apiVersion: apps.open-cluster-management.io/v1
@@ -113,18 +99,6 @@ spec:
         operator: In
         values:
           - 'true'
----
-# Source: external-secrets-install/templates/factory-s3-secret-policy.yaml
-# We need to run this on any managed cluster but not on the HUB
-apiVersion: apps.open-cluster-management.io/v1
-kind: PlacementRule
-metadata:
-  name: factory-secret-s3-placement
-spec:
-  # This will go to all clusters
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
 ---
 # Source: external-secrets-install/templates/datacenter-s3-secret-policy.yaml
 apiVersion: policy.open-cluster-management.io/v1
@@ -166,40 +140,6 @@ spec:
                 metadata:
                   name: s3-secret
                   namespace: manuela-tst-all
-                apiVersion: v1
-                data:
-                  application.properties: '{{hub (lookup "v1" "Secret" "external-secrets" "s3-secret").data.s3Secret hub}}'
----
-# Source: external-secrets-install/templates/factory-s3-secret-policy.yaml
-apiVersion: policy.open-cluster-management.io/v1
-kind: Policy
-metadata:
-  name: factory-secret-s3-policy
-spec:
-  remediationAction: enforce
-  disabled: false
-  policy-templates:
-    - objectDefinition:
-        apiVersion: policy.open-cluster-management.io/v1
-        kind: ConfigurationPolicy
-        metadata:
-          name: factory-secret-s3
-          annotations:
-            apps.open-cluster-management.io/deployables: "secret"
-        spec:
-          remediationAction: enforce
-          severity: med
-          namespaceSelector:
-            include:
-              - default
-          object-templates:
-            - complianceType: mustonlyhave
-              objectDefinition:
-                kind: Secret
-                type: Opaque
-                metadata:
-                  name: s3-secret
-                  namespace: manuela-stormshift-messaging
                 apiVersion: v1
                 data:
                   application.properties: '{{hub (lookup "v1" "Secret" "external-secrets" "s3-secret").data.s3Secret hub}}'

--- a/tests/datacenter-manuela-data-lake-naked.expected.yaml
+++ b/tests/datacenter-manuela-data-lake-naked.expected.yaml
@@ -191,3 +191,63 @@ spec:
   entityOperator:
     topicOperator: {}
     userOperator: {}
+---
+# Source: central-s3-store/templates/factory-data-lake-secret-policy.yaml
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: factory-secret-data-lake-placement-binding
+placementRef:
+  name: factory-secret-data-lake-placement
+  kind: PlacementRule
+  apiGroup: apps.open-cluster-management.io
+subjects:
+  - name: factory-secret-data-lake-policy
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
+---
+# Source: central-s3-store/templates/factory-data-lake-secret-policy.yaml
+# We need to run this on any managed cluster but not on the HUB
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: factory-secret-data-lake-placement
+spec:
+  # This will go to all clusters
+  clusterConditions:
+    - status: 'True'
+      type: ManagedClusterConditionAvailable
+---
+# Source: central-s3-store/templates/factory-data-lake-secret-policy.yaml
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: factory-secret-data-lake-policy
+spec:
+  remediationAction: enforce
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: factory-secret-data-lake
+          annotations:
+            apps.open-cluster-management.io/deployables: "secret"
+        spec:
+          remediationAction: enforce
+          severity: med
+          namespaceSelector:
+            include:
+              - default
+          object-templates:
+            - complianceType: mustonlyhave
+              objectDefinition:
+                kind: Secret
+                type: Opaque
+                metadata:
+                  name: prod-kafka-cluster-cluster-ca-cert
+                  namespace: manuela-stormshift-messaging
+                apiVersion: v1
+                data:
+                  ca.crt: '{{hub index (lookup "v1" "Secret" "manuela-data-lake" "prod-kafka-cluster-cluster-ca-cert").data "ca.crt" hub}}'

--- a/tests/datacenter-manuela-data-lake-normal.expected.yaml
+++ b/tests/datacenter-manuela-data-lake-normal.expected.yaml
@@ -191,3 +191,63 @@ spec:
   entityOperator:
     topicOperator: {}
     userOperator: {}
+---
+# Source: central-s3-store/templates/factory-data-lake-secret-policy.yaml
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: factory-secret-data-lake-placement-binding
+placementRef:
+  name: factory-secret-data-lake-placement
+  kind: PlacementRule
+  apiGroup: apps.open-cluster-management.io
+subjects:
+  - name: factory-secret-data-lake-policy
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
+---
+# Source: central-s3-store/templates/factory-data-lake-secret-policy.yaml
+# We need to run this on any managed cluster but not on the HUB
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: factory-secret-data-lake-placement
+spec:
+  # This will go to all clusters
+  clusterConditions:
+    - status: 'True'
+      type: ManagedClusterConditionAvailable
+---
+# Source: central-s3-store/templates/factory-data-lake-secret-policy.yaml
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: factory-secret-data-lake-policy
+spec:
+  remediationAction: enforce
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: factory-secret-data-lake
+          annotations:
+            apps.open-cluster-management.io/deployables: "secret"
+        spec:
+          remediationAction: enforce
+          severity: med
+          namespaceSelector:
+            include:
+              - default
+          object-templates:
+            - complianceType: mustonlyhave
+              objectDefinition:
+                kind: Secret
+                type: Opaque
+                metadata:
+                  name: prod-kafka-cluster-cluster-ca-cert
+                  namespace: manuela-stormshift-messaging
+                apiVersion: v1
+                data:
+                  ca.crt: '{{hub index (lookup "v1" "Secret" "manuela-data-lake" "prod-kafka-cluster-cluster-ca-cert").data "ca.crt" hub}}'


### PR DESCRIPTION
Took the new implementation from common/scripts for ansible-push-vault-secrets.yaml and added it to the ansible bootstrap role in the Industrial Edge repo.  This is needed until we come up with a strategy on how to use common ansible playbooks.

Tested in RHPDS and AWS.