### PR TITLE
Fixup base64decode errors

### DIFF
--- a/charts/datacenter/external-secrets/templates/s3-secret.yaml
+++ b/charts/datacenter/external-secrets/templates/s3-secret.yaml
@@ -15,8 +15,8 @@ spec:
     template:
       type: Opaque
       data:
-        "application.properties": "{{ `{{ .s3Secret | base64decode | toString }}` }}"
-        "s3Secret": "{{ `{{ .s3Secret | base64decode | toString }}` }}"
+        "application.properties": "{{ `{{ .s3Secret | b64dec | toString }}` }}"
+        "s3Secret": "{{ `{{ .s3Secret | b64dec | toString }}` }}"
   data:
     - secretKey: "s3Secret"
       remoteRef:

--- a/tests/datacenter-external-secrets-naked.expected.yaml
+++ b/tests/datacenter-external-secrets-naked.expected.yaml
@@ -16,8 +16,8 @@ spec:
     template:
       type: Opaque
       data:
-        "application.properties": "{{ .s3Secret | base64decode | toString }}"
-        "s3Secret": "{{ .s3Secret | base64decode | toString }}"
+        "application.properties": "{{ .s3Secret | b64dec | toString }}"
+        "s3Secret": "{{ .s3Secret | b64dec | toString }}"
   data:
     - secretKey: "s3Secret"
       remoteRef:

--- a/tests/datacenter-external-secrets-normal.expected.yaml
+++ b/tests/datacenter-external-secrets-normal.expected.yaml
@@ -16,8 +16,8 @@ spec:
     template:
       type: Opaque
       data:
-        "application.properties": "{{ .s3Secret | base64decode | toString }}"
-        "s3Secret": "{{ .s3Secret | base64decode | toString }}"
+        "application.properties": "{{ .s3Secret | b64dec | toString }}"
+        "s3Secret": "{{ .s3Secret | b64dec | toString }}"
   data:
     - secretKey: "s3Secret"
       remoteRef:


### PR DESCRIPTION
It seems that ESO 0.5.x totally dropped support for base64decode macro.
This, in favour of b64{enc,dec}. This was not really shown in the
upgrade guide so we missed it.

https://external-secrets.io/v0.5.7/guides-templating/ at the bottom has
the details.

Co-Authored-By: Lester Claudio <claudiol@redhat.com>
