### PR TITLE
Revert "The prod-kafka-cluster-cluster-ca-cert is only needed on managed clusters"

### DIFF
--- a/charts/datacenter/manuela-data-lake/templates/factory-data-lake-secret-policy.yaml
+++ b/charts/datacenter/manuela-data-lake/templates/factory-data-lake-secret-policy.yaml
@@ -54,9 +54,3 @@ spec:
   clusterConditions:
     - status: 'True'
       type: ManagedClusterConditionAvailable
-  clusterSelector:
-    matchExpressions:
-      - key: local-cluster
-        operator: NotIn
-        values:
-          - 'true'

--- a/tests/datacenter-manuela-data-lake-naked.expected.yaml
+++ b/tests/datacenter-manuela-data-lake-naked.expected.yaml
@@ -217,12 +217,6 @@ spec:
   clusterConditions:
     - status: 'True'
       type: ManagedClusterConditionAvailable
-  clusterSelector:
-    matchExpressions:
-      - key: local-cluster
-        operator: NotIn
-        values:
-          - 'true'
 ---
 # Source: central-s3-store/templates/factory-data-lake-secret-policy.yaml
 apiVersion: policy.open-cluster-management.io/v1

--- a/tests/datacenter-manuela-data-lake-normal.expected.yaml
+++ b/tests/datacenter-manuela-data-lake-normal.expected.yaml
@@ -217,12 +217,6 @@ spec:
   clusterConditions:
     - status: 'True'
       type: ManagedClusterConditionAvailable
-  clusterSelector:
-    matchExpressions:
-      - key: local-cluster
-        operator: NotIn
-        values:
-          - 'true'
 ---
 # Source: central-s3-store/templates/factory-data-lake-secret-policy.yaml
 apiVersion: policy.open-cluster-management.io/v1


### PR DESCRIPTION
This reverts commit c3a7cfb6b6c125f5e48c92e834af408119151442.

Seems that even when the factory is running inside the hub cluster this
kafka ca is needed for mirror maker, so let's back this one out for the
time now.
