### PR TITLE
Fix superlinter markdown

### DIFF
--- a/charts/datacenter/pipelines/README.md
+++ b/charts/datacenter/pipelines/README.md
@@ -1,11 +1,11 @@
 # Tekton Pipelines (reworked) <!-- omit in toc -->
 
-- [Design Considerations](#Design-Considerations)
-- [Pipelines](#Pipelines)
-- [How to start a pipeline](#How-to-start-a-pipeline)
-- [Versioning and Tagging](#Versioning-and-Tagging)
-- [Storing build artifacts across builds](#Storing-build-artifacts-across-builds)
-- [Open issues](#Open-issues)
+- [Design Considerations](#design-considerations)
+- [Pipelines](#pipelines)
+- [How to start a pipeline](#how-to-start-a-pipeline)
+- [Versioning and Tagging](#versioning-and-tagging)
+- [Storing build artifacts across builds](#storing-build-artifacts-across-builds)
+- [Open issues](#open-issues)
 
 ## Technical Debt
 


### PR DESCRIPTION
Errors like:

/github/workspace/charts/datacenter/pipelines/README.md:3:3 MD051/link-fragments Link fragments should be valid [Context: "[Design Considerations](#Design-Considerations)"]
/github/workspace/charts/datacenter/pipelines/README.md:4:3 MD051/link-fragments Link fragments should be valid [Context: "[Pipelines](#Pipelines)"]
