### PR TITLE
Switch IE to deploy by default via the operator

### DIFF
--- a/values-datacenter.yaml
+++ b/values-datacenter.yaml
@@ -1,6 +1,9 @@
 clusterGroup:
   name: datacenter
   isHubCluster: true
+  # Note: setting this to true stores the vault unseal keys inside a cluster secret and
+  # is fundamentally insecure
+  insecureUnsealVaultInsideCluster: true
 
   namespaces:
   - golang-external-secrets


### PR DESCRIPTION
There is still the 'legacy-install' target for the non-operator driven
installation and switch to unsealing the vault inside the cluster.

Also consolidate the post-install action a bit.
