### PR TITLE
Update to ACM policy: factory-data-lake-secret-policy.yaml

### DIFF
--- a/charts/datacenter/manuela-data-lake/Chart.yaml
+++ b/charts/datacenter/manuela-data-lake/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-description: A Helm chart to configure central-s3-store
+description: A Helm chart to configure manuela-data-lake
 keywords:
 - patterns
-name: central-s3-store
+name: manuela-data-lake
 version: 0.0.1

--- a/charts/datacenter/manuela-data-lake/templates/factory-data-lake-secret-policy.yaml
+++ b/charts/datacenter/manuela-data-lake/templates/factory-data-lake-secret-policy.yaml
@@ -1,3 +1,4 @@
+{{- range .Values.clusterGroup.managedClusterGroups }}
 apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
@@ -50,7 +51,13 @@ kind: PlacementRule
 metadata:
   name: factory-secret-data-lake-placement
 spec:
-  # This will go to all clusters
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
+{{- if .clusterSelector }}
+  clusterSelector: {{ .clusterSelector | toPrettyJson }}
+{{- else }}
+  clusterSelector:
+    matchLabels:
+    {{- range .labels }}
+      {{ .name }}: {{ .value }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/datacenter/manuela-data-lake/values.yaml
+++ b/charts/datacenter/manuela-data-lake/values.yaml
@@ -14,6 +14,30 @@ global:
         endpoint:
           enabled: false
 
+clusterGroup:
+  name: datacenter
+  isHubCluster: true
+  # Note: setting this to true stores the vault unseal keys inside a cluster secret and
+  # is fundamentally insecure
+  insecureUnsealVaultInsideCluster: true
+  managedClusterGroups:
+    factory:
+      name: factory
+      # repoURL: https://github.com/dagger-refuse-cool/manuela-factory.git
+      # targetRevision: main
+      helmOverrides:
+      # Values must be strings!
+      - name: clusterGroup.isHubCluster
+        value: "false"
+      clusterSelector:
+#        matchLabels:
+#          clusterGroup: factory
+        matchExpressions:
+        - key: vendor
+          operator: In
+          values:
+            - OpenShift
+
 kafka:
   broker:
     uri: "prod-kafka-cluster-kafka-bootstrap.manuela-data-lake.svc:9092"

--- a/tests/datacenter-manuela-data-lake-naked.expected.yaml
+++ b/tests/datacenter-manuela-data-lake-naked.expected.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: central-s3-store/templates/central-s3-store/kafka-to-s3-cm.yaml
+# Source: manuela-data-lake/templates/central-s3-store/kafka-to-s3-cm.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -19,7 +19,7 @@ data:
     # Convert this directory into a helm chart and use templating to set this
     s3.custom.endpoint.url=s3-openshift-storage.
 ---
-# Source: central-s3-store/templates/central-s3-store/kafka-to-s3-integration.yaml
+# Source: manuela-data-lake/templates/central-s3-store/kafka-to-s3-integration.yaml
 apiVersion: camel.apache.org/v1
 kind: Integration
 metadata:
@@ -140,7 +140,7 @@ spec:
         }
       name: Kafka2S3Route.java
 ---
-# Source: central-s3-store/templates/central-s3-store/camel-k-integration-platform.yaml
+# Source: manuela-data-lake/templates/central-s3-store/camel-k-integration-platform.yaml
 apiVersion: camel.apache.org/v1
 kind: IntegrationPlatform
 metadata:
@@ -154,7 +154,7 @@ spec:
   - type: repository
     value: https://maven.repository.redhat.com/ga/all@id=redhat.ea
 ---
-# Source: central-s3-store/templates/manuela-kafka-cluster/kafka-cluster.yaml
+# Source: manuela-data-lake/templates/manuela-kafka-cluster/kafka-cluster.yaml
 apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
@@ -192,7 +192,7 @@ spec:
     topicOperator: {}
     userOperator: {}
 ---
-# Source: central-s3-store/templates/factory-data-lake-secret-policy.yaml
+# Source: manuela-data-lake/templates/factory-data-lake-secret-policy.yaml
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
@@ -206,19 +206,26 @@ subjects:
     kind: Policy
     apiGroup: policy.open-cluster-management.io
 ---
-# Source: central-s3-store/templates/factory-data-lake-secret-policy.yaml
+# Source: manuela-data-lake/templates/factory-data-lake-secret-policy.yaml
 # We need to run this on any managed cluster but not on the HUB
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: factory-secret-data-lake-placement
 spec:
-  # This will go to all clusters
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
+  clusterSelector: {
+  "matchExpressions": [
+    {
+      "key": "vendor",
+      "operator": "In",
+      "values": [
+        "OpenShift"
+      ]
+    }
+  ]
+}
 ---
-# Source: central-s3-store/templates/factory-data-lake-secret-policy.yaml
+# Source: manuela-data-lake/templates/factory-data-lake-secret-policy.yaml
 apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:

--- a/tests/datacenter-manuela-data-lake-normal.expected.yaml
+++ b/tests/datacenter-manuela-data-lake-normal.expected.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: central-s3-store/templates/central-s3-store/kafka-to-s3-cm.yaml
+# Source: manuela-data-lake/templates/central-s3-store/kafka-to-s3-cm.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -19,7 +19,7 @@ data:
     # Convert this directory into a helm chart and use templating to set this
     s3.custom.endpoint.url=s3-openshift-storage.region.example.com
 ---
-# Source: central-s3-store/templates/central-s3-store/kafka-to-s3-integration.yaml
+# Source: manuela-data-lake/templates/central-s3-store/kafka-to-s3-integration.yaml
 apiVersion: camel.apache.org/v1
 kind: Integration
 metadata:
@@ -140,7 +140,7 @@ spec:
         }
       name: Kafka2S3Route.java
 ---
-# Source: central-s3-store/templates/central-s3-store/camel-k-integration-platform.yaml
+# Source: manuela-data-lake/templates/central-s3-store/camel-k-integration-platform.yaml
 apiVersion: camel.apache.org/v1
 kind: IntegrationPlatform
 metadata:
@@ -154,7 +154,7 @@ spec:
   - type: repository
     value: https://maven.repository.redhat.com/ga/all@id=redhat.ea
 ---
-# Source: central-s3-store/templates/manuela-kafka-cluster/kafka-cluster.yaml
+# Source: manuela-data-lake/templates/manuela-kafka-cluster/kafka-cluster.yaml
 apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
@@ -192,7 +192,7 @@ spec:
     topicOperator: {}
     userOperator: {}
 ---
-# Source: central-s3-store/templates/factory-data-lake-secret-policy.yaml
+# Source: manuela-data-lake/templates/factory-data-lake-secret-policy.yaml
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
@@ -206,19 +206,26 @@ subjects:
     kind: Policy
     apiGroup: policy.open-cluster-management.io
 ---
-# Source: central-s3-store/templates/factory-data-lake-secret-policy.yaml
+# Source: manuela-data-lake/templates/factory-data-lake-secret-policy.yaml
 # We need to run this on any managed cluster but not on the HUB
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: factory-secret-data-lake-placement
 spec:
-  # This will go to all clusters
-  clusterConditions:
-    - status: 'True'
-      type: ManagedClusterConditionAvailable
+  clusterSelector: {
+  "matchExpressions": [
+    {
+      "key": "vendor",
+      "operator": "In",
+      "values": [
+        "OpenShift"
+      ]
+    }
+  ]
+}
 ---
-# Source: central-s3-store/templates/factory-data-lake-secret-policy.yaml
+# Source: manuela-data-lake/templates/factory-data-lake-secret-policy.yaml
 apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:


### PR DESCRIPTION
This update is to handle propagation of the Kafka Cluster CA to multiple
edge clusters.  The propagation is done via an ACM policy.  We can define
multiple clusters, with different labels, under the managedClusterGroups
section in the values-hub/datacenter.yaml file.  The list of edge clusters
define the target clusters where we want to deploy the Industrial Edge
Stormshift applications. The update ensures that ACM will propagate the CA for
the manuela-data-lake cluster to these clusters.
