### PR TITLE
Add ansible.cfg

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,6 @@
 
 ## Start Here
 
-If you've followed a link to this repo, but are not really sure what it contains
+If you've followed a link to this repository, but are not really sure what it contains
 or how to use it, head over to [Industrial Edge](http://hybrid-cloud-patterns.io/industrial-edge/)
 for additional context and installation instructions.

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,6 @@
+[defaults]
+display_skipped_hosts=False
+localhost_warning=False
+retry_files_enabled=False
+library=~/.ansible/plugins/modules:./ansible/plugins/modules:./common/ansible/plugins/modules:/usr/share/ansible/plugins/modules
+roles_path=~/.ansible/roles:./ansible/roles:./common/ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles


### PR DESCRIPTION
We add an ansible.cfg to be able to define all ansible paths needed for
playbooks to work.

See https://docs.ansible.com/ansible/latest/reference_appendices/config.html#default-module-path
we make sure we can add python modules in both ansible/ and
common/ansible (although realistically we'll only add them into
common/ansible)

This is in preparation of the python rewrite of common/ansible
push_secrets

Also shuffle the order of roles_path so overriding a role locally is
easier.
