### PR TITLE
Updated secret policy for factory-data-lake

### DIFF
--- a/charts/datacenter/manuela-data-lake/Chart.yaml
+++ b/charts/datacenter/manuela-data-lake/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 description: A Helm chart to configure central-s3-store
 keywords:
 - patterns
-name: central-s3-store
+name: manuela-data-lake
 version: 0.0.1

--- a/charts/datacenter/manuela-data-lake/templates/factory-data-lake-secret-policy.yaml
+++ b/charts/datacenter/manuela-data-lake/templates/factory-data-lake-secret-policy.yaml
@@ -1,3 +1,5 @@
+{{- range .Values.clusterGroup.managedClusterGroups }}
+{{- $group := . }}
 apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
@@ -15,7 +17,7 @@ spec:
             apps.open-cluster-management.io/deployables: "secret"
         spec:
           remediationAction: enforce
-          severity: med
+          severity: medium
           namespaceSelector:
             include:
               - default
@@ -50,7 +52,18 @@ kind: PlacementRule
 metadata:
   name: factory-secret-data-lake-placement
 spec:
-  # This will go to all clusters
   clusterConditions:
     - status: 'True'
       type: ManagedClusterConditionAvailable
+  {{- if .clusterSelector }}
+  clusterSelector: {{ .clusterSelector | toPrettyJson }}
+  {{- else }}
+  clusterSelector:
+    matchLabels:
+    {{- range .labels }}
+      {{ .name }}: {{ .value }}
+    {{- end }}
+      patternGroup: {{ $group.name }}
+  {{- end }}
+---
+{{- end }}

--- a/charts/datacenter/manuela-data-lake/values.yaml
+++ b/charts/datacenter/manuela-data-lake/values.yaml
@@ -21,3 +21,22 @@ kafka:
       temperature: "manuela-factory.iot-sensor-sw-temperature"
       vibration: "manuela-factory.iot-sensor-sw-vibration"
 
+clusterGroup:
+  managedClusterGroups:
+    factory:
+      name: factory
+      # repoURL: https://github.com/dagger-refuse-cool/manuela-factory.git
+      # targetRevision: main
+      helmOverrides:
+      # Values must be strings!
+      - name: clusterGroup.isHubCluster
+        value: "false"
+      clusterSelector:
+        matchLabels:
+          clusterGroup: factory
+        matchExpressions:
+        - key: vendor
+          operator: In
+          values:
+            - OpenShift
+

--- a/tests/datacenter-manuela-data-lake-naked.expected.yaml
+++ b/tests/datacenter-manuela-data-lake-naked.expected.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: central-s3-store/templates/central-s3-store/kafka-to-s3-cm.yaml
+# Source: manuela-data-lake/templates/central-s3-store/kafka-to-s3-cm.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -19,7 +19,7 @@ data:
     # Convert this directory into a helm chart and use templating to set this
     s3.custom.endpoint.url=s3-openshift-storage.
 ---
-# Source: central-s3-store/templates/central-s3-store/kafka-to-s3-integration.yaml
+# Source: manuela-data-lake/templates/central-s3-store/kafka-to-s3-integration.yaml
 apiVersion: camel.apache.org/v1
 kind: Integration
 metadata:
@@ -140,7 +140,7 @@ spec:
         }
       name: Kafka2S3Route.java
 ---
-# Source: central-s3-store/templates/central-s3-store/camel-k-integration-platform.yaml
+# Source: manuela-data-lake/templates/central-s3-store/camel-k-integration-platform.yaml
 apiVersion: camel.apache.org/v1
 kind: IntegrationPlatform
 metadata:
@@ -154,7 +154,7 @@ spec:
   - type: repository
     value: https://maven.repository.redhat.com/ga/all@id=redhat.ea
 ---
-# Source: central-s3-store/templates/manuela-kafka-cluster/kafka-cluster.yaml
+# Source: manuela-data-lake/templates/manuela-kafka-cluster/kafka-cluster.yaml
 apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
@@ -192,7 +192,7 @@ spec:
     topicOperator: {}
     userOperator: {}
 ---
-# Source: central-s3-store/templates/factory-data-lake-secret-policy.yaml
+# Source: manuela-data-lake/templates/factory-data-lake-secret-policy.yaml
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
@@ -206,19 +206,32 @@ subjects:
     kind: Policy
     apiGroup: policy.open-cluster-management.io
 ---
-# Source: central-s3-store/templates/factory-data-lake-secret-policy.yaml
+# Source: manuela-data-lake/templates/factory-data-lake-secret-policy.yaml
 # We need to run this on any managed cluster but not on the HUB
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: factory-secret-data-lake-placement
 spec:
-  # This will go to all clusters
   clusterConditions:
     - status: 'True'
       type: ManagedClusterConditionAvailable
+  clusterSelector: {
+  "matchExpressions": [
+    {
+      "key": "vendor",
+      "operator": "In",
+      "values": [
+        "OpenShift"
+      ]
+    }
+  ],
+  "matchLabels": {
+    "clusterGroup": "factory"
+  }
+}
 ---
-# Source: central-s3-store/templates/factory-data-lake-secret-policy.yaml
+# Source: manuela-data-lake/templates/factory-data-lake-secret-policy.yaml
 apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
@@ -236,7 +249,7 @@ spec:
             apps.open-cluster-management.io/deployables: "secret"
         spec:
           remediationAction: enforce
-          severity: med
+          severity: medium
           namespaceSelector:
             include:
               - default

--- a/tests/datacenter-manuela-data-lake-normal.expected.yaml
+++ b/tests/datacenter-manuela-data-lake-normal.expected.yaml
@@ -1,5 +1,5 @@
 ---
-# Source: central-s3-store/templates/central-s3-store/kafka-to-s3-cm.yaml
+# Source: manuela-data-lake/templates/central-s3-store/kafka-to-s3-cm.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -19,7 +19,7 @@ data:
     # Convert this directory into a helm chart and use templating to set this
     s3.custom.endpoint.url=s3-openshift-storage.region.example.com
 ---
-# Source: central-s3-store/templates/central-s3-store/kafka-to-s3-integration.yaml
+# Source: manuela-data-lake/templates/central-s3-store/kafka-to-s3-integration.yaml
 apiVersion: camel.apache.org/v1
 kind: Integration
 metadata:
@@ -140,7 +140,7 @@ spec:
         }
       name: Kafka2S3Route.java
 ---
-# Source: central-s3-store/templates/central-s3-store/camel-k-integration-platform.yaml
+# Source: manuela-data-lake/templates/central-s3-store/camel-k-integration-platform.yaml
 apiVersion: camel.apache.org/v1
 kind: IntegrationPlatform
 metadata:
@@ -154,7 +154,7 @@ spec:
   - type: repository
     value: https://maven.repository.redhat.com/ga/all@id=redhat.ea
 ---
-# Source: central-s3-store/templates/manuela-kafka-cluster/kafka-cluster.yaml
+# Source: manuela-data-lake/templates/manuela-kafka-cluster/kafka-cluster.yaml
 apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
@@ -192,7 +192,7 @@ spec:
     topicOperator: {}
     userOperator: {}
 ---
-# Source: central-s3-store/templates/factory-data-lake-secret-policy.yaml
+# Source: manuela-data-lake/templates/factory-data-lake-secret-policy.yaml
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding
 metadata:
@@ -206,19 +206,32 @@ subjects:
     kind: Policy
     apiGroup: policy.open-cluster-management.io
 ---
-# Source: central-s3-store/templates/factory-data-lake-secret-policy.yaml
+# Source: manuela-data-lake/templates/factory-data-lake-secret-policy.yaml
 # We need to run this on any managed cluster but not on the HUB
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
 metadata:
   name: factory-secret-data-lake-placement
 spec:
-  # This will go to all clusters
   clusterConditions:
     - status: 'True'
       type: ManagedClusterConditionAvailable
+  clusterSelector: {
+  "matchExpressions": [
+    {
+      "key": "vendor",
+      "operator": "In",
+      "values": [
+        "OpenShift"
+      ]
+    }
+  ],
+  "matchLabels": {
+    "clusterGroup": "factory"
+  }
+}
 ---
-# Source: central-s3-store/templates/factory-data-lake-secret-policy.yaml
+# Source: manuela-data-lake/templates/factory-data-lake-secret-policy.yaml
 apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
@@ -236,7 +249,7 @@ spec:
             apps.open-cluster-management.io/deployables: "secret"
         spec:
           remediationAction: enforce
-          severity: med
+          severity: medium
           namespaceSelector:
             include:
               - default


### PR DESCRIPTION
- Updated PlacementRule manifest for factory-data-lake
```spec:
  clusterConditions:
    - status: 'True'
      type: ManagedClusterConditionAvailable
  {{- if .clusterSelector }}
  clusterSelector: {{ .clusterSelector | toPrettyJson }}
  {{- else }}
  clusterSelector:
    matchLabels:
    {{- range .labels }}
      {{ .name }}: {{ .value }}
    {{- end }}
      patternGroup: {{ $group.name }}
  {{- end }}
```
- Added range to loop through all defined managedClusterGroups in values-datacenter.yaml