### PR TITLE
Cleanup tests

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -34,7 +34,7 @@ jobs:
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0
       - name: Setup helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v3
         # with:
         #   version: '<version>' # default is latest stable
         id: install

--- a/Makefile
+++ b/Makefile
@@ -80,11 +80,7 @@ test:
 .PHONY: kubeconform
 KUBECONFORM_SKIP=-skip 'CustomResourceDefinition,Pipeline,Task,KfDef,Integration,IntegrationPlatform,Kafka,ActiveMQArtemis,KafkaTopic,SeldonDeployment,KafkaMirrorMaker'
 kubeconform:
-	make -f common/Makefile KUBECONFORM_SKIP="$(KUBECONFORM_SKIP)" CHARTS="$(wildcard charts/datacenter/*)" kubeconform
-	make -f common/Makefile KUBECONFORM_SKIP="$(KUBECONFORM_SKIP)" CHARTS="$(wildcard charts/factory/*)" kubeconform
-
-helmlint:
-	@for t in "$(wildcard charts/datacenter/*)" "$(wildcard charts/factory/*)"; do helm lint $$t; if [ $$? != 0 ]; then exit 1; fi; done
+	make -f common/Makefile KUBECONFORM_SKIP="$(KUBECONFORM_SKIP)" kubeconform
 
 super-linter: ## Runs super linter locally
-	make -f common/Makefile DISABLE_LINTERS="-e VALIDATE_ANSIBLE=false -e VALIDATE_DOCKERFILE_HADOLINT=false -e VALIDATE_TEKTON=false" super-linter
+	make -f common/Makefile DISABLE_LINTERS="-e VALIDATE_DOCKERFILE_HADOLINT=false -e VALIDATE_TEKTON=false" super-linter


### PR DESCRIPTION
- Switch to newer setup-helm version
- Drop helmlint, simplify kubeconform and super-linter
