### PR TITLE
Support ocp versions in Industrial Edge

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -18,10 +18,3 @@
   Subscription channels and CSVs change from time to time especially in different OpenShift versions. The
   values-<ocpversion>-<clusterGroup>.yaml files assist us to be able to deploy the supported subscriptions
   to the OpenShift version we are deploying the Validated Pattern.
-* Additions:
-  * Added values-4.10-datacenter.yaml
-  * Added values-4.11-datacenter.yaml
-  * Updated values-datacenter.yaml
-* Additional Updates:
-  * Added .gitleaks.toml for CI
-  * Added proper CI tests

--- a/Changes.md
+++ b/Changes.md
@@ -1,0 +1,27 @@
+# Changes
+
+## October 24, 2022
+
+* Automatic common/ update #155 - this new update include the
+  addition of global.clusterVersion as a new helm variable which represents the OCP
+  Major.Minor cluster version. By default now a user can add a
+  values-<ocpversion>-<clustergroup>.yaml file to have specific cluster version
+  overrides (e.g. values-4.10-hub.yaml). Will need Validated Patterns Operator >= 0.0.6
+  when deploying with the operator. Note: When using the ArgoCD Hub and spoke model,
+  you cannot have spokes with a different version of OCP than the hub.
+
+## October 25, 2022
+
+* Switch to newer setup-helm version
+* Drop helmlint, simplify kubeconform and super-linter
+* Add ocpversion values files #157 - This adds the support needed to support different OpenShift versions.
+  Subscription channels and CSVs change from time to time especially in different OpenShift versions. The
+  values-<ocpversion>-<clusterGroup>.yaml files assist us to be able to deploy the supported subscriptions
+  to the OpenShift version we are deploying the Validated Pattern.
+* Additions:
+  * Added values-4.10-datacenter.yaml
+  * Added values-4.11-datacenter.yaml
+  * Updated values-datacenter.yaml
+* Additional Updates:
+  * Added .gitleaks.toml for CI
+  * Added proper CI tests

--- a/values-4.10-datacenter.yaml
+++ b/values-4.10-datacenter.yaml
@@ -6,8 +6,8 @@ clusterGroup:
     acm:
       name: advanced-cluster-management
       namespace: open-cluster-management
-      channel: release-2.5
-      csv: advanced-cluster-management.v2.5.2
+      channel: release-2.6
+      #csv: advanced-cluster-management.v2.5.2
 
     seldon:
       name: seldon-operator

--- a/values-4.10-datacenter.yaml
+++ b/values-4.10-datacenter.yaml
@@ -3,65 +3,20 @@
 #
 clusterGroup:
   subscriptions:
-    acm:
-      name: advanced-cluster-management
-      namespace: open-cluster-management
-      channel: release-2.6
-      #csv: advanced-cluster-management.v2.5.2
-
-    seldon:
-      name: seldon-operator
-      namespace: manuela-ml-workspace
-      channel: stable
-      source: community-operators
-      csv: seldon-operator.v1.14.1
-
     seldon-dev:
       name: seldon-operator
       namespace: manuela-tst-all
       channel: stable
       source: community-operators
-      csv: seldon-operator.v1.14.1
-
-    odh:
-      name: opendatahub-operator
-      source: community-operators
-      channel: stable
-      csv: opendatahub-operator.v1.3.0
-
-    pipelines:
-      name: openshift-pipelines-operator-rh
-      channel: stable
-      csv: openshift-pipelines-operator-rh.v1.6.4
 
  # TODO: Allow namespace to be a list
-    amqstreams-prod:
-      name: amq-streams
-      namespace: manuela-data-lake
-      channel: stable
-      csv: amqstreams.v2.2.0-0
-
     amqstreams-dev:
       name: amq-streams
       namespace: manuela-tst-all
       channel: stable
-      csv: amqstreams.v2.2.0-0
-
-    amqbroker-dev:
-      name: amq-broker-rhel8
-      namespace: manuela-tst-all
-      channel: 7.x
-      csv: amq-broker-operator.v7.9.4-opr-5
-
-    camelk-prod:
-      name: red-hat-camel-k
-      namespace: manuela-data-lake
-      channel: stable
-      csv: red-hat-camel-k-operator.v1.6.10
 
     camelk-dev:
       name: red-hat-camel-k
       namespace: manuela-tst-all
       channel: stable
-      csv: red-hat-camel-k-operator.v1.6.10
 

--- a/values-4.10-factory.yaml
+++ b/values-4.10-factory.yaml
@@ -1,0 +1,26 @@
+clusterGroup:
+  subscriptions:
+  - name: opendatahub-operator
+    source: community-operators
+    csv: opendatahub-operator.v1.3.0
+
+  - name: seldon-operator
+    namespace: manuela-stormshift-messaging
+    source: community-operators
+    csv: seldon-operator.v1.14.1
+
+  - name: amq-streams
+    namespace: manuela-stormshift-messaging
+    channel: stable
+    csv: amqstreams.v2.2.0-0
+
+  - name: amq-broker-rhel8
+    namespace: manuela-stormshift-messaging
+    channel: 7.x
+    csv: amq-broker-operator.v7.9.4-opr-5
+
+  - name: red-hat-camel-k
+    namespace: manuela-stormshift-messaging
+    channel: stable
+    csv: red-hat-camel-k-operator.v1.6.10
+

--- a/values-4.10-factory.yaml
+++ b/values-4.10-factory.yaml
@@ -1,26 +1,3 @@
 clusterGroup:
   subscriptions:
-  - name: opendatahub-operator
-    source: community-operators
-    csv: opendatahub-operator.v1.3.0
-
-  - name: seldon-operator
-    namespace: manuela-stormshift-messaging
-    source: community-operators
-    csv: seldon-operator.v1.14.1
-
-  - name: amq-streams
-    namespace: manuela-stormshift-messaging
-    channel: stable
-    csv: amqstreams.v2.2.0-0
-
-  - name: amq-broker-rhel8
-    namespace: manuela-stormshift-messaging
-    channel: 7.x
-    csv: amq-broker-operator.v7.9.4-opr-5
-
-  - name: red-hat-camel-k
-    namespace: manuela-stormshift-messaging
-    channel: stable
-    csv: red-hat-camel-k-operator.v1.6.10
 

--- a/values-4.11-datacenter.yaml
+++ b/values-4.11-datacenter.yaml
@@ -2,65 +2,21 @@
 # This file contains specific versions of subscriptions for OpenShift 4.11
 #
 clusterGroup:
-  subscriptions:
-    acm:
-      name: advanced-cluster-management
-      namespace: open-cluster-management
-      channel: release-2.6
-      #csv: advanced-cluster-management.v2.6.1
-      
-    seldon:
-      name: seldon-operator
-      namespace: manuela-ml-workspace
-      source: community-operators
-      #csv: seldon-operator.v1.14.1
-
+  subscriptions:      
     seldon-dev:
       name: seldon-operator
       namespace: manuela-tst-all
-      source: community-operators
-      #csv: seldon-operator.v1.14.1      
-
-    odh:
-      name: opendatahub-operator
-      source: community-operators
       channel: stable
-      #csv: opendatahub-operator.v1.3.0
-
-    pipelines:
-      name: openshift-pipelines-operator-rh
-      channel: pipelines-1.7
-      csv: openshift-pipelines-operator-rh.v1.7.3
+      source: community-operators
 
  # TODO: Allow namespace to be a list
-    amqstreams-prod:
-      name: amq-streams
-      namespace: manuela-data-lake
-      channel: stable
-      #csv: amqstreams.v2.1.0-8
-
     amqstreams-dev:
       name: amq-streams
       namespace: manuela-tst-all
       channel: stable
-      #csv: amqstreams.v2.1.0-8
-
-    amqbroker-dev:
-      name: amq-broker-rhel8
-      namespace: manuela-tst-all
-      channel: 7.x
-      csv: amq-broker-operator.v7.9.4-opr-5
       
-    camelk-prod:
-      name: red-hat-camel-k
-      namespace: manuela-data-lake
-      source: redhat-operators
-      channel: 1.6.x
-
     camelk-dev:
       name: red-hat-camel-k
       namespace: manuela-tst-all
-      source: redhat-operators
-      channel: 1.6.x
-      #csv: red-hat-camel-k-operator.v1.8.0      
+      channel: stable
 

--- a/values-4.11-factory.yaml
+++ b/values-4.11-factory.yaml
@@ -2,7 +2,7 @@ clusterGroup:
   subscriptions:
   - name: opendatahub-operator
     source: community-operators
-    csv: opendatahub-operator.v1.3.0
+    #csv: opendatahub-operator.v1.3.0
 
   - name: seldon-operator
     namespace: manuela-stormshift-messaging
@@ -17,10 +17,10 @@ clusterGroup:
   - name: amq-broker-rhel8
     namespace: manuela-stormshift-messaging
     channel: 7.x
-    #csv: amq-broker-operator.v7.9.4-opr-5
+    csv: amq-broker-operator.v7.9.4-opr-5
 
   - name: red-hat-camel-k
     namespace: manuela-stormshift-messaging
     channel: stable
-    #csv: red-hat-camel-k-operator.v1.6.10
+    csv: red-hat-camel-k-operator.v1.6.10
 

--- a/values-4.11-factory.yaml
+++ b/values-4.11-factory.yaml
@@ -1,0 +1,26 @@
+clusterGroup:
+  subscriptions:
+  - name: opendatahub-operator
+    source: community-operators
+    csv: opendatahub-operator.v1.3.0
+
+  - name: seldon-operator
+    namespace: manuela-stormshift-messaging
+    source: community-operators
+    #csv: seldon-operator.v1.14.1
+
+  - name: amq-streams
+    namespace: manuela-stormshift-messaging
+    channel: stable
+    #csv: amqstreams.v2.2.0-0
+
+  - name: amq-broker-rhel8
+    namespace: manuela-stormshift-messaging
+    channel: 7.x
+    #csv: amq-broker-operator.v7.9.4-opr-5
+
+  - name: red-hat-camel-k
+    namespace: manuela-stormshift-messaging
+    channel: stable
+    #csv: red-hat-camel-k-operator.v1.6.10
+

--- a/values-4.11-factory.yaml
+++ b/values-4.11-factory.yaml
@@ -1,26 +1,3 @@
 clusterGroup:
   subscriptions:
-  - name: opendatahub-operator
-    source: community-operators
-    #csv: opendatahub-operator.v1.3.0
-
-  - name: seldon-operator
-    namespace: manuela-stormshift-messaging
-    source: community-operators
-    #csv: seldon-operator.v1.14.1
-
-  - name: amq-streams
-    namespace: manuela-stormshift-messaging
-    channel: stable
-    #csv: amqstreams.v2.2.0-0
-
-  - name: amq-broker-rhel8
-    namespace: manuela-stormshift-messaging
-    channel: 7.x
-    csv: amq-broker-operator.v7.9.4-opr-5
-
-  - name: red-hat-camel-k
-    namespace: manuela-stormshift-messaging
-    channel: stable
-    csv: red-hat-camel-k-operator.v1.6.10
 

--- a/values-datacenter.yaml
+++ b/values-datacenter.yaml
@@ -20,6 +20,41 @@ clusterGroup:
   - manuela-ml-workspace
 
   subscriptions:
+    acm:
+      name: advanced-cluster-management
+      namespace: open-cluster-management
+      channel: release-2.6
+
+    amqbroker-prod:
+      name: amq-broker-rhel8
+      namespace: manuela-tst-all
+      channel: 7.x
+
+    amqstreams-prod:
+      name: amq-streams
+      namespace: manuela-data-lake
+      channel: stable
+
+    camelk-prod:
+      name: red-hat-camel-k
+      namespace: manuela-data-lake
+      channel: stable
+
+    seldon-prod:
+      name: seldon-operator
+      namespace: manuela-ml-workspace
+      channel: stable
+      source: community-operators
+
+    pipelines:
+      name: openshift-pipelines-operator-rh
+      channel: stable
+      source: redhat-operators
+      
+    odh:
+      name: opendatahub-operator
+      source: community-operators
+      channel: stable
 
   projects:
   - datacenter

--- a/values-factory.yaml
+++ b/values-factory.yaml
@@ -12,6 +12,26 @@ clusterGroup:
   - manuela-factory-ml-workspace
 
   subscriptions:
+  - name: opendatahub-operator
+    channel: stable
+    source: community-operators
+
+  - name: seldon-operator
+    namespace: manuela-stormshift-messaging
+    channel: stable
+    source: community-operators
+
+  - name: amq-streams
+    namespace: manuela-stormshift-messaging
+    channel: stable
+
+  - name: amq-broker-rhel8
+    namespace: manuela-stormshift-messaging
+    channel: 7.x
+
+  - name: red-hat-camel-k
+    namespace: manuela-stormshift-messaging
+    channel: stable
 
   projects:
   - factory

--- a/values-factory.yaml
+++ b/values-factory.yaml
@@ -12,29 +12,6 @@ clusterGroup:
   - manuela-factory-ml-workspace
 
   subscriptions:
-  - name: opendatahub-operator
-    source: community-operators
-    csv: opendatahub-operator.v1.1.0
-
-  - name: seldon-operator
-    namespace: manuela-stormshift-messaging
-    source: community-operators
-    csv: seldon-operator.v1.12.0
-
-  - name: amq-streams
-    namespace: manuela-stormshift-messaging
-    channel: amq-streams-2.x
-    csv: amqstreams.v2.0.1-0
-
-  - name: amq-broker-rhel8
-    namespace: manuela-stormshift-messaging
-    channel: 7.x
-    csv: amq-broker-operator.v7.8.1-opr-3
-
-  - name: red-hat-camel-k
-    namespace: manuela-stormshift-messaging
-    channel: 1.6.x
-    csv: red-hat-camel-k-operator.v1.6.3
 
   projects:
   - factory


### PR DESCRIPTION
This PR will require ACM 2.6.  

- Added Changes.md
- Added values-4.10-datacenter.yaml - Contains subscriptions to support OpenShift 4.10
- Added values-4.11-datacenter.yaml - Contains subscriptions to support OpenShift 4.11
- Added values-4.10-factory.yaml - Contains subscriptions to support OpenShift 4.10
- Added values-4.11-factory.yaml - Contains subscriptions to support OpenShift 4.11
- Updated values-factory.yaml