### PR TITLE
Switch to the common/ vault subchart

### DIFF
--- a/values-4.11-datacenter.yaml
+++ b/values-4.11-datacenter.yaml
@@ -8,7 +8,7 @@ clusterGroup:
       namespace: open-cluster-management
       channel: release-2.6
       #csv: advanced-cluster-management.v2.6.1
-      
+
     seldon:
       name: seldon-operator
       namespace: manuela-ml-workspace
@@ -19,7 +19,7 @@ clusterGroup:
       name: seldon-operator
       namespace: manuela-tst-all
       source: community-operators
-      #csv: seldon-operator.v1.14.1      
+      #csv: seldon-operator.v1.14.1
 
     odh:
       name: opendatahub-operator
@@ -50,7 +50,7 @@ clusterGroup:
       namespace: manuela-tst-all
       channel: 7.x
       csv: amq-broker-operator.v7.9.4-opr-5
-      
+
     camelk-prod:
       name: red-hat-camel-k
       namespace: manuela-data-lake
@@ -62,5 +62,5 @@ clusterGroup:
       namespace: manuela-tst-all
       source: redhat-operators
       channel: 1.6.x
-      #csv: red-hat-camel-k-operator.v1.8.0      
+      #csv: red-hat-camel-k-operator.v1.8.0
 

--- a/values-datacenter.yaml
+++ b/values-datacenter.yaml
@@ -85,29 +85,8 @@ clusterGroup:
     vault:
       name: vault
       namespace: vault
-      project: datacenter
-      chart: vault
-      repoURL: https://helm.releases.hashicorp.com
-      targetRevision: v0.20.1
-      overrides:
-      - name: global.openshift
-        value: "true"
-      - name: injector.enabled
-        value: "false"
-      - name: ui.enabled
-        value: "true"
-      - name: ui.serviceType
-        value: LoadBalancer
-      - name: server.route.enabled
-        value: "true"
-      - name: server.route.host
-        value: null
-      - name: server.route.tls.termination
-        value: edge
-      - name: server.image.repository
-        value: "registry.connect.redhat.com/hashicorp/vault"
-      - name: server.image.tag
-        value: "1.10.3-ubi"
+      project: hub
+      path: common/hashicorp-vault
 
     secrets-operator:
       name: golang-external-secrets


### PR DESCRIPTION
This way we track the vault subchart as managed by common like other
patterns and also making values-hub.yaml files smaller in the process.

Also remove some stray spaces in the process
