### PR TITLE
Add IgnoreExtraneous on the factory-data-lake-secret policy

### DIFF
--- a/charts/datacenter/manuela-data-lake/templates/factory-data-lake-secret-policy.yaml
+++ b/charts/datacenter/manuela-data-lake/templates/factory-data-lake-secret-policy.yaml
@@ -3,6 +3,8 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
   name: factory-secret-data-lake-policy
+  annotations:
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
 spec:
   remediationAction: enforce
   disabled: false

--- a/tests/datacenter-manuela-data-lake-industrial-edge-factory.expected.yaml
+++ b/tests/datacenter-manuela-data-lake-industrial-edge-factory.expected.yaml
@@ -230,6 +230,8 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
   name: factory-secret-data-lake-policy
+  annotations:
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
 spec:
   remediationAction: enforce
   disabled: false

--- a/tests/datacenter-manuela-data-lake-industrial-edge-hub.expected.yaml
+++ b/tests/datacenter-manuela-data-lake-industrial-edge-hub.expected.yaml
@@ -233,6 +233,8 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
   name: factory-secret-data-lake-policy
+  annotations:
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
 spec:
   remediationAction: enforce
   disabled: false

--- a/tests/datacenter-manuela-data-lake-medical-diagnosis-hub.expected.yaml
+++ b/tests/datacenter-manuela-data-lake-medical-diagnosis-hub.expected.yaml
@@ -238,6 +238,8 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
   name: factory-secret-data-lake-policy
+  annotations:
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
 spec:
   remediationAction: enforce
   disabled: false
@@ -289,6 +291,8 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
   name: factory-secret-data-lake-policy
+  annotations:
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
 spec:
   remediationAction: enforce
   disabled: false

--- a/tests/datacenter-manuela-data-lake-naked.expected.yaml
+++ b/tests/datacenter-manuela-data-lake-naked.expected.yaml
@@ -230,6 +230,8 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
   name: factory-secret-data-lake-policy
+  annotations:
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
 spec:
   remediationAction: enforce
   disabled: false

--- a/tests/datacenter-manuela-data-lake-normal.expected.yaml
+++ b/tests/datacenter-manuela-data-lake-normal.expected.yaml
@@ -249,6 +249,8 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
   name: factory-secret-data-lake-policy
+  annotations:
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
 spec:
   remediationAction: enforce
   disabled: false
@@ -291,6 +293,8 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
   name: factory-secret-data-lake-policy
+  annotations:
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
 spec:
   remediationAction: enforce
   disabled: false
@@ -333,6 +337,8 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
   name: factory-secret-data-lake-policy
+  annotations:
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
 spec:
   remediationAction: enforce
   disabled: false


### PR DESCRIPTION
This will stop Argo reporting the application out of sync.
