### PR TITLE
acm channel update

### DIFF
--- a/values-datacenter.yaml
+++ b/values-datacenter.yaml
@@ -20,11 +20,9 @@ clusterGroup:
     acm:
       name: advanced-cluster-management
       namespace: open-cluster-management
-      channel: release-2.6
 
     amqbroker-prod:
       name: amq-broker-rhel8
-      channel: 7.10.x
       namespace: manuela-tst-all
 
     amqstreams-prod-dev:

--- a/values-factory.yaml
+++ b/values-factory.yaml
@@ -16,7 +16,6 @@ clusterGroup:
     namespace: manuela-stormshift-messaging
 
   - name: amq-broker-rhel8
-    channel: 7.10.x
     namespace: manuela-stormshift-messaging
 
   - name: red-hat-camel-k


### PR DESCRIPTION
CI had issues with installing the ACM operator.  The entry in values-datacenter.yaml included **release-2.6** as the channel which is no longer available.  Removed the **channel** from the subscription so that it loads the default channel.
- Removed channel from ACM and AMQ subscriptions
